### PR TITLE
회원가입 검증 및 예외 처리 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ out/
 
 
 # local config
+src/main/resources/application-local.yaml
 src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.security:spring-security-crypto'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:4.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.passay:passay:1.6.4'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:4.0.1'

--- a/src/main/java/com/jian/hobbyadventure/common/exception/BusinessException.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.jian.hobbyadventure.common.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
@@ -4,9 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
-    DUPLICATE_EMAIL_OR_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 이메일 또는 닉네임입니다.");
+    DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 값입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.jian.hobbyadventure.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    DUPLICATE_EMAIL_OR_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 이메일 또는 닉네임입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.jian.hobbyadventure.common.exception;
+
+import com.jian.hobbyadventure.common.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(message));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorResponse.of(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.of("서버 오류"));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.jian.hobbyadventure.common.exception;
 
 import com.jian.hobbyadventure.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -23,6 +25,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected error", e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.of("서버 오류"));
     }
 }

--- a/src/main/java/com/jian/hobbyadventure/common/response/ErrorResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/common/response/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.jian.hobbyadventure.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private final String message;
+
+    private ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/common/validator/PasswordConstraintValidator.java
+++ b/src/main/java/com/jian/hobbyadventure/common/validator/PasswordConstraintValidator.java
@@ -1,0 +1,45 @@
+package com.jian.hobbyadventure.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.passay.*;
+
+import java.util.List;
+import java.util.Properties;
+
+public class PasswordConstraintValidator implements ConstraintValidator<ValidPassword, String> {
+
+    private PasswordValidator validator;
+
+    @Override
+    public void initialize(ValidPassword constraintAnnotation) {
+        Properties props = new Properties();
+        props.setProperty("TOO_SHORT", "비밀번호는 8자 이상이어야 합니다.");
+        props.setProperty("TOO_LONG", "비밀번호는 32자 이하여야 합니다.");
+        props.setProperty("INSUFFICIENT_ALPHABETICAL", "비밀번호는 영문자를 포함해야 합니다.");
+        props.setProperty("INSUFFICIENT_DIGIT", "비밀번호는 숫자를 포함해야 합니다.");
+        props.setProperty("INSUFFICIENT_SPECIAL", "비밀번호는 특수문자를 포함해야 합니다.");
+
+        MessageResolver resolver = new PropertiesMessageResolver(props);
+
+        validator = new PasswordValidator(resolver,
+                new LengthRule(8, 32),
+                new CharacterRule(EnglishCharacterData.Alphabetical, 1),
+                new CharacterRule(EnglishCharacterData.Digit, 1),
+                new CharacterRule(EnglishCharacterData.Special, 1)
+        );
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+
+        RuleResult result = validator.validate(new PasswordData(value));
+        if (result.isValid()) return true;
+
+        List<String> messages = validator.getMessages(result);
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(messages.get(0)).addConstraintViolation();
+        return false;
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/common/validator/ValidPassword.java
+++ b/src/main/java/com/jian/hobbyadventure/common/validator/ValidPassword.java
@@ -1,0 +1,16 @@
+package com.jian.hobbyadventure.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PasswordConstraintValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+    String message() default "비밀번호 형식이 올바르지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.jian.hobbyadventure.common.response.ApiResponse;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.dto.response.SignupResponse;
 import com.jian.hobbyadventure.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +20,7 @@ public class AuthController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody SignupRequest request) {
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         userService.signup(request);
         return ResponseEntity.ok(ApiResponse.of(new SignupResponse(true)));
     }

--- a/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.jian.hobbyadventure.dto.response.SignupResponse;
 import com.jian.hobbyadventure.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,6 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         userService.signup(request);
-        return ResponseEntity.ok(ApiResponse.of(new SignupResponse(true)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(new SignupResponse(true)));
     }
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/request/SignupRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/SignupRequest.java
@@ -1,5 +1,9 @@
 package com.jian.hobbyadventure.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +13,20 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignupRequest {
 
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 32, message = "비밀번호는 8자 이상 32자 이하로 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{}|;:'\",.<>/?\\\\])[A-Za-z\\d!@#$%^&*()\\-_=+\\[\\]{}|;:'\",.<>/?\\\\]+$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."
+    )
     private String password;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하로 입력해주세요.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
     private String nickname;
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/request/SignupRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/SignupRequest.java
@@ -1,9 +1,11 @@
 package com.jian.hobbyadventure.dto.request;
 
+import com.jian.hobbyadventure.common.validator.ValidPassword;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,11 +20,7 @@ public class SignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Size(min = 8, max = 32, message = "비밀번호는 8자 이상 32자 이하로 입력해주세요.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{}|;:'\",.<>/?\\\\])[A-Za-z\\d!@#$%^&*()\\-_=+\\[\\]{}|;:'\",.<>/?\\\\]+$",
-            message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."
-    )
+    @ValidPassword
     private String password;
 
     @NotBlank(message = "닉네임을 입력해주세요.")

--- a/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
@@ -4,9 +4,16 @@ import com.jian.hobbyadventure.domain.User;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface UserMapper {
+
+    @Select("SELECT EXISTS(SELECT 1 FROM users WHERE email = #{email})")
+    boolean existsByEmail(String email);
+
+    @Select("SELECT EXISTS(SELECT 1 FROM users WHERE nickname = #{nickname})")
+    boolean existsByNickname(String nickname);
 
     @Insert("""
             INSERT INTO users (email, password, nickname)

--- a/src/main/java/com/jian/hobbyadventure/service/UserService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/UserService.java
@@ -19,10 +19,10 @@ public class UserService {
 
     public void signup(SignupRequest request) {
         if (userMapper.existsByEmail(request.getEmail())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+            throw new BusinessException(ErrorCode.DUPLICATED);
         }
         if (userMapper.existsByNickname(request.getNickname())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+            throw new BusinessException(ErrorCode.DUPLICATED);
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
@@ -31,7 +31,7 @@ public class UserService {
         try {
             userMapper.insert(user);
         } catch (DuplicateKeyException e) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL_OR_NICKNAME);
+            throw new BusinessException(ErrorCode.DUPLICATED);
         }
     }
 }

--- a/src/main/java/com/jian/hobbyadventure/service/UserService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/UserService.java
@@ -1,9 +1,12 @@
 package com.jian.hobbyadventure.service;
 
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.repository.UserMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,8 +18,20 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public void signup(SignupRequest request) {
+        if (userMapper.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        if (userMapper.existsByNickname(request.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         User user = User.create(request.getEmail(), encodedPassword, request.getNickname());
-        userMapper.insert(user);
+
+        try {
+            userMapper.insert(user);
+        } catch (DuplicateKeyException e) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL_OR_NICKNAME);
+        }
     }
 }

--- a/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
@@ -134,26 +134,26 @@ class AuthControllerTest {
     @Test
     void signup_이메일_중복_시_409를_반환한다() throws Exception {
         SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네임");
-        doThrow(new BusinessException(ErrorCode.DUPLICATE_EMAIL))
+        doThrow(new BusinessException(ErrorCode.DUPLICATED))
                 .when(userService).signup(any(SignupRequest.class));
 
         mockMvc.perform(post("/api/v1/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다."));
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 값입니다."));
     }
 
     @Test
     void signup_닉네임_중복_시_409를_반환한다() throws Exception {
         SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네임");
-        doThrow(new BusinessException(ErrorCode.DUPLICATE_NICKNAME))
+        doThrow(new BusinessException(ErrorCode.DUPLICATED))
                 .when(userService).signup(any(SignupRequest.class));
 
         mockMvc.perform(post("/api/v1/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 값입니다."));
     }
 }

--- a/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
@@ -84,7 +84,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상 32자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상이어야 합니다."));
     }
 
     @Test
@@ -95,7 +95,40 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."));
+                .andExpect(jsonPath("$.message").value("비밀번호는 특수문자를 포함해야 합니다."));
+    }
+
+    @Test
+    void signup_비밀번호_영문자_없을_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "12345678!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호는 영문자를 포함해야 합니다."));
+    }
+
+    @Test
+    void signup_비밀번호_숫자_없을_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcdefgh!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호는 숫자를 포함해야 합니다."));
+    }
+
+    @Test
+    void signup_비밀번호_32자_초과_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!Abcd1234!Abcd1234!Abcd12!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호는 32자 이하여야 합니다."));
     }
 
     @Test

--- a/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
@@ -29,14 +29,14 @@ class AuthControllerTest {
     private UserService userService;
 
     @Test
-    void signup_성공_시_200_응답을_반환한다() throws Exception {
+    void signup_성공_시_201_응답을_반환한다() throws Exception {
         SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네임");
         doNothing().when(userService).signup(any(SignupRequest.class));
 
         mockMvc.perform(post("/api/v1/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.success").value(true));
     }
 }

--- a/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
@@ -1,5 +1,7 @@
 package com.jian.hobbyadventure.controller;
 
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.service.UserService;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,5 +41,119 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.success").value(true));
+    }
+
+    @Test
+    void signup_이메일_누락_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest(null, "Abcd1234!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이메일을 입력해주세요."));
+    }
+
+    @Test
+    void signup_이메일_형식_오류_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("invalid-email", "Abcd1234!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."));
+    }
+
+    @Test
+    void signup_비밀번호_누락_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", null, "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호를 입력해주세요."));
+    }
+
+    @Test
+    void signup_비밀번호_길이_위반_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Ab1!", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상 32자 이하로 입력해주세요."));
+    }
+
+    @Test
+    void signup_비밀번호_문자_조건_위반_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd12345", "닉네임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."));
+    }
+
+    @Test
+    void signup_닉네임_누락_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", null);
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("닉네임을 입력해주세요."));
+    }
+
+    @Test
+    void signup_닉네임_길이_위반_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("닉네임은 2자 이상 12자 이하로 입력해주세요."));
+    }
+
+    @Test
+    void signup_닉네임_문자_위반_시_400을_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네 임");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("닉네임은 한글, 영문, 숫자만 사용할 수 있습니다."));
+    }
+
+    @Test
+    void signup_이메일_중복_시_409를_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네임");
+        doThrow(new BusinessException(ErrorCode.DUPLICATE_EMAIL))
+                .when(userService).signup(any(SignupRequest.class));
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다."));
+    }
+
+    @Test
+    void signup_닉네임_중복_시_409를_반환한다() throws Exception {
+        SignupRequest request = new SignupRequest("test@example.com", "Abcd1234!", "닉네임");
+        doThrow(new BusinessException(ErrorCode.DUPLICATE_NICKNAME))
+                .when(userService).signup(any(SignupRequest.class));
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
     }
 }

--- a/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.jian.hobbyadventure.service;
 
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.repository.UserMapper;
@@ -9,9 +11,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +52,40 @@ class UserServiceTest {
 
         userService.signup(request);
 
-        verify(userMapper).insert(org.mockito.ArgumentMatchers.any(User.class));
+        verify(userMapper).insert(any(User.class));
+    }
+
+    @Test
+    void signup_이메일_중복_시_BusinessException을_던진다() {
+        SignupRequest request = new SignupRequest("test@example.com", "rawPassword", "닉네임");
+        when(userMapper.existsByEmail(request.getEmail())).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+    }
+
+    @Test
+    void signup_닉네임_중복_시_BusinessException을_던진다() {
+        SignupRequest request = new SignupRequest("test@example.com", "rawPassword", "닉네임");
+        when(userMapper.existsByNickname(request.getNickname())).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    void signup_insert_중_DuplicateKeyException_발생_시_BusinessException을_던진다() {
+        SignupRequest request = new SignupRequest("test@example.com", "rawPassword", "닉네임");
+        when(passwordEncoder.encode("rawPassword")).thenReturn("encodedPassword");
+        doThrow(new DuplicateKeyException("duplicate")).when(userMapper).insert(any(User.class));
+
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL_OR_NICKNAME);
     }
 }

--- a/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
@@ -63,7 +63,7 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.signup(request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+                .isEqualTo(ErrorCode.DUPLICATED);
     }
 
     @Test
@@ -74,7 +74,7 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.signup(request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+                .isEqualTo(ErrorCode.DUPLICATED);
     }
 
     @Test
@@ -86,6 +86,6 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.signup(request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.DUPLICATE_EMAIL_OR_NICKNAME);
+                .isEqualTo(ErrorCode.DUPLICATED);
     }
 }


### PR DESCRIPTION
## 개요
회원가입 요청값 검증과 예외 응답 처리를 구현했습니다.

## Issue
- #3 회원가입 입력 검증 및 예외 처리

## 구현 내용
- 이메일 형식 검증
SignupRequest DTO에 @Email, @NotBlank를 적용하여 이메일 형식을 검증하도록 구성했습니다.

- 비밀번호 형식 검증
@Size, @Pattern을 사용하여 비밀번호 길이 및 영문/숫자/특수문자 포함 조건을 검증하도록 구성했습니다.

- 닉네임 길이 검증
@Size를 사용하여 닉네임 길이를 2자 이상 12자 이하로 제한했습니다.

- 닉네임 허용 문자 검증
@Pattern을 사용하여 한글, 영문, 숫자만 허용하도록 정규식을 적용했습니다.

- 중복 예외 응답 처리
Service에서 이메일/닉네임 중복 여부를 사전 조회 후 BusinessException을 발생시키도록 했으며, DB insert 시 DuplicateKeyException 발생 경우에도 예외를 변환하여 처리하도록 구성했습니다.

- 공통 에러 메시지 정리
ErrorCode enum을 통해 상태 코드와 메시지를 함께 관리하도록 구성했고,
GlobalExceptionHandler를 통해 예외를 일관된 ErrorResponse 형태로 반환하도록 처리했습니다.

## Done
잘못된 요청에 대해 400 응답을 반환합니다.
이메일/닉네임 중복 시 409 응답을 반환합니다.
예외 메시지가 문서와 일치합니다.
이메일/닉네임 중복 시 저장되지 않습니다.

## 리뷰 시 참고 사항
- 요청값 검증은 Controller에서 @Valid를 통해 처리하고,
비즈니스 로직 관련 예외는 Service에서 처리하도록 역할을 분리했습니다.

- 예외는 GlobalExceptionHandler에서 일괄 처리하여 응답 포맷을 통일했습니다.

- 중복 체크는 Service에서 사전 조회로 1차 검증을 수행하고,
DB insert 시 발생할 수 있는 DuplicateKeyException을 catch하여 2차 방어를 추가했습니다.


## 리뷰 요청
중복 체크를 사전 조회 + DB 예외 처리 방식으로 이중 처리했는데,
이 방식이 실무에서도 일반적으로 사용하는 패턴인지 궁금합니다.

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 관련 issue와 연결했습니다.
- [x] 셀프 리뷰를 진행했습니다.
- [x] 테스트를 통해 정상 동작을 확인했습니다.