### PR TITLE
로그인 기능 구현 

### DIFF
--- a/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
@@ -4,7 +4,8 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
-    DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 값입니다.");
+    DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 값입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
@@ -2,7 +2,9 @@ package com.jian.hobbyadventure.controller;
 
 import com.jian.hobbyadventure.common.response.CommonResponse;
 import com.jian.hobbyadventure.common.response.ErrorResponse;
+import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.dto.response.SignupResponse;
 import com.jian.hobbyadventure.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.springframework.http.HttpStatus.OK;
+
 @Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -27,6 +31,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = userService.login(request);
+        return ResponseEntity.status(OK).body(CommonResponse.of(response));
+    }
 
     @Operation(summary = "회원가입")
     @ApiResponses({

--- a/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/AuthController.java
@@ -32,6 +32,12 @@ public class AuthController {
 
     private final UserService userService;
 
+    @Operation(summary = "로그인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class)), description = "입력값 검증 실패\n\n- 이메일: 누락 또는 형식 오류\n\n- 비밀번호: 누락"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class)), description = "이메일 또는 비밀번호 불일치")
+    })
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);

--- a/src/main/java/com/jian/hobbyadventure/domain/User.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/User.java
@@ -1,5 +1,6 @@
 package com.jian.hobbyadventure.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class User {
 
     private Long userId;

--- a/src/main/java/com/jian/hobbyadventure/dto/request/LoginRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.jian.hobbyadventure.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/request/LoginRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.jian.hobbyadventure.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -11,10 +12,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginRequest {
 
+    @Schema(description = "이메일", example = "test@example.com", format = "email")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "Abcd1234!")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.jian.hobbyadventure.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private final Long userId;
+    private final String nickname;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.jian.hobbyadventure.dto.response;
 
+import com.jian.hobbyadventure.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +10,8 @@ public class LoginResponse {
 
     private final Long userId;
     private final String nickname;
+
+    public static LoginResponse from(User user) {
+        return new LoginResponse(user.getUserId(), user.getNickname());
+    }
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/LoginResponse.java
@@ -1,14 +1,19 @@
 package com.jian.hobbyadventure.dto.response;
 
 import com.jian.hobbyadventure.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Schema(description = "로그인 응답")
 @Getter
 @AllArgsConstructor
 public class LoginResponse {
 
+    @Schema(description = "사용자 ID", example = "1")
     private final Long userId;
+
+    @Schema(description = "닉네임", example = "홍길동")
     private final String nickname;
 
     public static LoginResponse from(User user) {

--- a/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
@@ -1,10 +1,15 @@
 package com.jian.hobbyadventure.repository;
 
 import com.jian.hobbyadventure.domain.User;
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Mapper
 public interface UserMapper {
@@ -14,6 +19,16 @@ public interface UserMapper {
 
     @Select("SELECT EXISTS(SELECT 1 FROM users WHERE nickname = #{nickname})")
     boolean existsByNickname(String nickname);
+
+    @ConstructorArgs({
+            @Arg(column = "user_id", javaType = Long.class),
+            @Arg(column = "email", javaType = String.class),
+            @Arg(column = "password", javaType = String.class),
+            @Arg(column = "nickname", javaType = String.class),
+            @Arg(column = "created_at", javaType = LocalDateTime.class)
+    })
+    @Select("SELECT * FROM users WHERE email = #{email}")
+    Optional<User> findByEmail(String email);
 
     @Insert("""
             INSERT INTO users (email, password, nickname)

--- a/src/main/java/com/jian/hobbyadventure/service/UserService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/UserService.java
@@ -3,7 +3,9 @@ package com.jian.hobbyadventure.service;
 import com.jian.hobbyadventure.common.exception.BusinessException;
 import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
+import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
@@ -16,6 +18,17 @@ public class UserService {
 
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userMapper.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return LoginResponse.from(user);
+    }
 
     public void signup(SignupRequest request) {
         if (userMapper.existsByEmail(request.getEmail())) {

--- a/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/AuthControllerTest.java
@@ -2,7 +2,9 @@ package com.jian.hobbyadventure.controller;
 
 import com.jian.hobbyadventure.common.exception.BusinessException;
 import com.jian.hobbyadventure.common.exception.ErrorCode;
+import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,6 +33,65 @@ class AuthControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @Test
+    void login_성공_시_200_응답을_반환한다() throws Exception {
+        LoginRequest request = new LoginRequest("test@example.com", "Abcd1234!");
+        when(userService.login(any(LoginRequest.class))).thenReturn(new LoginResponse(1L, "닉네임"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.nickname").value("닉네임"));
+    }
+
+    @Test
+    void login_이메일_누락_시_400을_반환한다() throws Exception {
+        LoginRequest request = new LoginRequest(null, "Abcd1234!");
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이메일을 입력해주세요."));
+    }
+
+    @Test
+    void login_이메일_형식_오류_시_400을_반환한다() throws Exception {
+        LoginRequest request = new LoginRequest("invalid-email", "Abcd1234!");
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."));
+    }
+
+    @Test
+    void login_비밀번호_누락_시_400을_반환한다() throws Exception {
+        LoginRequest request = new LoginRequest("test@example.com", null);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("비밀번호를 입력해주세요."));
+    }
+
+    @Test
+    void login_인증_실패_시_401을_반환한다() throws Exception {
+        LoginRequest request = new LoginRequest("test@example.com", "Abcd1234!");
+        doThrow(new BusinessException(ErrorCode.INVALID_CREDENTIALS))
+                .when(userService).login(any(LoginRequest.class));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 올바르지 않습니다."));
+    }
 
     @Test
     void signup_성공_시_201_응답을_반환한다() throws Exception {

--- a/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
@@ -3,7 +3,9 @@ package com.jian.hobbyadventure.service;
 import com.jian.hobbyadventure.common.exception.BusinessException;
 import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
+import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +15,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +37,43 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Test
+    void login_성공_시_userId와_nickname을_반환한다() {
+        User user = new User(1L, "test@example.com", "encodedPassword", "닉네임", LocalDateTime.now());
+        LoginRequest request = new LoginRequest("test@example.com", "rawPassword");
+        when(userMapper.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+        LoginResponse response = userService.login(request);
+
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getNickname()).isEqualTo("닉네임");
+    }
+
+    @Test
+    void login_존재하지_않는_이메일_시_BusinessException을_던진다() {
+        LoginRequest request = new LoginRequest("test@example.com", "rawPassword");
+        when(userMapper.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    @Test
+    void login_비밀번호_불일치_시_BusinessException을_던진다() {
+        User user = new User(1L, "test@example.com", "encodedPassword", "닉네임", LocalDateTime.now());
+        LoginRequest request = new LoginRequest("test@example.com", "wrongPassword");
+        when(userMapper.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+        assertThatThrownBy(() -> userService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_CREDENTIALS);
+    }
 
     @Test
     void signup_호출_시_비밀번호가_암호화되어_insert된다() {


### PR DESCRIPTION
## 개요
로그인 요청을 받아 사용자 정보를 검증하는 기능을 구현했습니다.

## Issue
- #8 

## 구현 내용
- 로그인 Request / Response DTO 작성
- 이메일 기반 사용자 조회 로직 구현
- 비밀번호 검증 로직 구현
- 로그인 API 구현

## Done
- 이메일, 비밀번호를 통해 로그인 요청을 처리할 수 있습니다.
- 비밀번호 일치 여부를 검증할 수 있습니다.

## 리뷰 시 참고 사항
- DTO ↔ Domain 변환 책임을 DTO에 두는 방식으로 구성했습니다.
- 비밀번호는 @RequestBody를 통해 전달받고, 추후 HTTPS 적용을 전제로 설계했습니다.
- 로그인 응답에는 클라이언트 사용성을 고려하여 userId, nickname을 포함했습니다.

## 리뷰 요청

아래 설계 방향에 대해 의견 부탁드립니다.

1. DTO ↔ Domain 변환을 DTO에서 담당하도록 구성했습니다.  
   Service의 책임을 줄이고 변환 로직의 역할을 명확히 하기 위한 선택인데,  
   이 방식이 적절한지 의견 부탁드립니다.

2. 비밀번호는 @RequestBody로 전달받도록 구현했습니다.  
   HTTPS 환경에서는 문제가 없다고 판단했는데,  
   이 접근 방식이 괜찮은지 궁금합니다.

3. 로그인 응답에 userId, nickname을 포함했습니다.  
   클라이언트에서 로그인 상태를 활용하기 위한 목적이었는데,  
   이 정도 수준의 정보 반환이 적절한지 의견 부탁드립니다.

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 관련 issue와 연결했습니다.
- [x] 셀프 리뷰를 진행했습니다.
- [x] 테스트를 통해 정상 동작을 확인했습니다.