### PR TITLE
회원 탈퇴 기능 구현 

### DIFF
--- a/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 값입니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jian/hobbyadventure/controller/UserController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.jian.hobbyadventure.controller;
+
+import com.jian.hobbyadventure.common.response.CommonResponse;
+import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
+import com.jian.hobbyadventure.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<CommonResponse<DeleteAccountResponse>> deleteAccount(@PathVariable Long userId) {
+        DeleteAccountResponse response = userService.deleteAccount(userId);
+        return ResponseEntity.status(OK).body(CommonResponse.of(response));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/controller/UserController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/UserController.java
@@ -1,8 +1,15 @@
 package com.jian.hobbyadventure.controller;
 
 import com.jian.hobbyadventure.common.response.CommonResponse;
+import com.jian.hobbyadventure.common.response.ErrorResponse;
 import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
 import com.jian.hobbyadventure.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.http.HttpStatus.OK;
 
+@Tag(name = "User", description = "사용자 API")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -19,6 +27,11 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "회원탈퇴")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class)), description = "존재하지 않는 사용자")
+    })
     @DeleteMapping("/{userId}")
     public ResponseEntity<CommonResponse<DeleteAccountResponse>> deleteAccount(@PathVariable Long userId) {
         DeleteAccountResponse response = userService.deleteAccount(userId);

--- a/src/main/java/com/jian/hobbyadventure/dto/response/DeleteAccountResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/DeleteAccountResponse.java
@@ -1,0 +1,11 @@
+package com.jian.hobbyadventure.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteAccountResponse {
+
+    private final boolean success;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/DeleteAccountResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/DeleteAccountResponse.java
@@ -1,11 +1,14 @@
 package com.jian.hobbyadventure.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Schema(description = "회원탈퇴 응답")
 @Getter
 @AllArgsConstructor
 public class DeleteAccountResponse {
 
+    @Schema(description = "탈퇴 성공 여부", example = "true")
     private final boolean success;
 }

--- a/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/UserMapper.java
@@ -3,6 +3,7 @@ package com.jian.hobbyadventure.repository;
 import com.jian.hobbyadventure.domain.User;
 import org.apache.ibatis.annotations.Arg;
 import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -29,6 +30,19 @@ public interface UserMapper {
     })
     @Select("SELECT * FROM users WHERE email = #{email}")
     Optional<User> findByEmail(String email);
+
+    @ConstructorArgs({
+            @Arg(column = "user_id", javaType = Long.class),
+            @Arg(column = "email", javaType = String.class),
+            @Arg(column = "password", javaType = String.class),
+            @Arg(column = "nickname", javaType = String.class),
+            @Arg(column = "created_at", javaType = LocalDateTime.class)
+    })
+    @Select("SELECT * FROM users WHERE user_id = #{userId}")
+    Optional<User> findById(Long userId);
+
+    @Delete("DELETE FROM users WHERE user_id = #{userId}")
+    void deleteById(Long userId);
 
     @Insert("""
             INSERT INTO users (email, password, nickname)

--- a/src/main/java/com/jian/hobbyadventure/service/UserService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/UserService.java
@@ -5,6 +5,7 @@ import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
 import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
 import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,14 @@ public class UserService {
 
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
+
+    public DeleteAccountResponse deleteAccount(Long userId) {
+        userMapper.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        userMapper.deleteById(userId);
+        return new DeleteAccountResponse(true);
+    }
 
     public LoginResponse login(LoginRequest request) {
         User user = userMapper.findByEmail(request.getEmail())

--- a/src/test/java/com/jian/hobbyadventure/controller/UserControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/UserControllerTest.java
@@ -1,0 +1,46 @@
+package com.jian.hobbyadventure.controller;
+
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
+import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
+import com.jian.hobbyadventure.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Test
+    void deleteAccount_성공_시_200_응답을_반환한다() throws Exception {
+        when(userService.deleteAccount(1L)).thenReturn(new DeleteAccountResponse(true));
+
+        mockMvc.perform(delete("/api/v1/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.success").value(true));
+    }
+
+    @Test
+    void deleteAccount_존재하지_않는_userId_시_404를_반환한다() throws Exception {
+        doThrow(new BusinessException(ErrorCode.NOT_FOUND))
+                .when(userService).deleteAccount(1L);
+
+        mockMvc.perform(delete("/api/v1/users/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("요청하신 정보를 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.domain.User;
 import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
+import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
 import com.jian.hobbyadventure.dto.response.LoginResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +39,29 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Test
+    void deleteAccount_성공_시_success가_true를_반환한다() {
+        User user = new User(1L, "test@example.com", "encodedPassword", "닉네임", LocalDateTime.now());
+        when(userMapper.findById(1L)).thenReturn(Optional.of(user));
+
+        DeleteAccountResponse response = userService.deleteAccount(1L);
+
+        assertThat(response.isSuccess()).isTrue();
+        verify(userMapper).deleteById(1L);
+    }
+
+    @Test
+    void deleteAccount_존재하지_않는_userId_시_BusinessException을_던진다() {
+        when(userMapper.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.deleteAccount(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+
+        verify(userMapper, never()).deleteById(any());
+    }
 
     @Test
     void login_성공_시_userId와_nickname을_반환한다() {


### PR DESCRIPTION
## 개요
회원 탈퇴 요청을 받아 사용자 계정을 삭제하는 기능을 구현했습니다.

## Issue
- #10 

## 구현 내용
- 회원 탈퇴 Response DTO 작성
- PathVariable 기반 사용자 식별 처리
- 회원 탈퇴 API 구현
- 사용자 삭제 로직 구현

## Done
- 사용자 식별자를 기반으로 회원 탈퇴 요청을 처리할 수 있습니다.
- 회원 탈퇴 시 사용자 정보가 삭제됩니다.
- 탈퇴 결과를 응답 DTO로 반환할 수 있습니다.

## 리뷰 시 참고 사항

- 회원 탈퇴 API URL을 `/users/{userId}` 형태로 구성했습니다.  
  추후 JWT 기반 인증 도입 시 `/users/me` 형태로 변경될 가능성이 있으며,  
  사용자 식별 방식도 PathVariable에서 토큰 기반으로 변경될 수 있습니다.  
  현재는 포트폴리오 단계로 구현 단순성을 우선하여 해당 방식을 선택했습니다.

- 회원 탈퇴는 Hard Delete 방식으로 구현했습니다.  
  Soft Delete 적용 시 이력 관리 및 복구 측면에서 장점이 있지만,  
  현재 단계에서는 구현 복잡도를 고려하여 단순 삭제 방식으로 진행했습니다.

- 회원 탈퇴 응답은 204 No Content 대신 200 OK와 응답 바디를 반환하도록 구성했습니다.  
  단순 리소스 삭제가 아닌 사용자 입장에서 중요한 액션이라고 판단하여  
  성공 여부를 명확히 전달하는 방향을 선택했습니다.

## 리뷰 요청

아래 설계 방향에 대해 의견 부탁드립니다.

1. 회원 탈퇴 API URL을 `/users/{userId}`로 구성했습니다.  
   추후 JWT 기반 인증 도입 시 `/users/me` 형태로 변경될 가능성이 있는데,  
   현재 단계에서 이와 같은 URL 설계가 적절한지 궁금합니다.

2. 회원 탈퇴는 Hard Delete 방식으로 구현했습니다.  
   Soft Delete 방식과 비교했을 때, 포트폴리오 단계에서는 이 선택이 적절한지 의견 부탁드립니다.

3. 회원 탈퇴 응답을 204 No Content 대신 200 OK와 응답 바디를 반환하도록 구성했습니다.  
   사용자 관점에서 중요한 액션이라고 판단했는데, 이와 같은 응답 방식이 적절한지 궁금합니다.

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 관련 issue와 연결했습니다.
- [x] 셀프 리뷰를 진행했습니다.
- [x] 테스트를 통해 정상 동작을 확인했습니다.