### PR TITLE
카테고리 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/jian/hobbyadventure/controller/CategoryController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/CategoryController.java
@@ -3,6 +3,10 @@ package com.jian.hobbyadventure.controller;
 import com.jian.hobbyadventure.common.response.CommonResponse;
 import com.jian.hobbyadventure.dto.response.CategoryResponse;
 import com.jian.hobbyadventure.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Category", description = "카테고리 API")
 @RestController
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
@@ -18,6 +23,10 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
+    @Operation(summary = "카테고리 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공 (데이터 없을 경우 빈 배열 반환)")
+    })
     @GetMapping
     public ResponseEntity<CommonResponse<List<CategoryResponse>>> getCategories() {
         List<CategoryResponse> categories = categoryService.getCategories();

--- a/src/main/java/com/jian/hobbyadventure/controller/CategoryController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package com.jian.hobbyadventure.controller;
+
+import com.jian.hobbyadventure.common.response.CommonResponse;
+import com.jian.hobbyadventure.dto.response.CategoryResponse;
+import com.jian.hobbyadventure.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<List<CategoryResponse>>> getCategories() {
+        List<CategoryResponse> categories = categoryService.getCategories();
+        return ResponseEntity.ok(CommonResponse.of(categories));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/domain/Category.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/Category.java
@@ -1,0 +1,16 @@
+package com.jian.hobbyadventure.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    private Long categoryId;
+    private String code;
+    private String name;
+    private int displayOrder;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/CategoryResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/CategoryResponse.java
@@ -1,0 +1,22 @@
+package com.jian.hobbyadventure.dto.response;
+
+import com.jian.hobbyadventure.domain.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryResponse {
+
+    private Long categoryId;
+    private String code;
+    private String name;
+
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getCategoryId(),
+                category.getCode(),
+                category.getName()
+        );
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/repository/CategoryMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/CategoryMapper.java
@@ -1,0 +1,22 @@
+package com.jian.hobbyadventure.repository;
+
+import com.jian.hobbyadventure.domain.Category;
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface CategoryMapper {
+
+    @ConstructorArgs({
+            @Arg(column = "category_id", javaType = Long.class),
+            @Arg(column = "code", javaType = String.class),
+            @Arg(column = "name", javaType = String.class),
+            @Arg(column = "display_order", javaType = int.class)
+    })
+    @Select("SELECT category_id, code, name, display_order FROM categories ORDER BY display_order")
+    List<Category> findAll();
+}

--- a/src/main/java/com/jian/hobbyadventure/service/CategoryService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/CategoryService.java
@@ -1,0 +1,22 @@
+package com.jian.hobbyadventure.service;
+
+import com.jian.hobbyadventure.dto.response.CategoryResponse;
+import com.jian.hobbyadventure.repository.CategoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryMapper categoryMapper;
+
+    public List<CategoryResponse> getCategories() {
+        return categoryMapper.findAll()
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+}

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -9,3 +9,24 @@ CREATE TABLE users
     UNIQUE KEY uk_users_email (email),
     UNIQUE KEY uk_users_nickname (nickname)
 );
+
+CREATE TABLE categories
+(
+    category_id   BIGINT      NOT NULL AUTO_INCREMENT,
+    code          VARCHAR(50) NOT NULL,
+    name          VARCHAR(50) NOT NULL,
+    display_order INT         NOT NULL,
+    PRIMARY KEY (category_id),
+    UNIQUE KEY uk_categories_code (code),
+    UNIQUE KEY uk_categories_display_order (display_order)
+);
+
+INSERT INTO categories (code, name, display_order)
+VALUES ('EXERCISE', '운동', 1),
+       ('VISIT', '방문', 2),
+       ('GATHERING', '모임', 3),
+       ('CREATION', '창작', 4),
+       ('LEARNING', '학습', 5),
+       ('APPRECIATION', '감상', 6),
+       ('REST', '휴식', 7),
+       ('ETC', '기타', 8);

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -1,3 +1,5 @@
+SET NAMES 'utf8mb4';
+
 CREATE TABLE users
 (
     user_id    BIGINT       NOT NULL AUTO_INCREMENT,

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -23,12 +23,3 @@ CREATE TABLE categories
     UNIQUE KEY uk_categories_display_order (display_order)
 );
 
-INSERT INTO categories (code, name, display_order)
-VALUES ('EXERCISE', '운동', 1),
-       ('VISIT', '방문', 2),
-       ('GATHERING', '모임', 3),
-       ('CREATION', '창작', 4),
-       ('LEARNING', '학습', 5),
-       ('APPRECIATION', '감상', 6),
-       ('REST', '휴식', 7),
-       ('ETC', '기타', 8);

--- a/src/main/resources/sql/dml.sql
+++ b/src/main/resources/sql/dml.sql
@@ -1,0 +1,11 @@
+SET NAMES 'utf8mb4';
+
+INSERT INTO categories (code, name, display_order)
+VALUES ('EXERCISE', '운동', 1),
+       ('VISIT', '방문', 2),
+       ('GATHERING', '모임', 3),
+       ('CREATION', '창작', 4),
+       ('LEARNING', '학습', 5),
+       ('APPRECIATION', '감상', 6),
+       ('REST', '휴식', 7),
+       ('ETC', '기타', 8);

--- a/src/test/java/com/jian/hobbyadventure/controller/CategoryControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/CategoryControllerTest.java
@@ -1,0 +1,49 @@
+package com.jian.hobbyadventure.controller;
+
+import com.jian.hobbyadventure.dto.response.CategoryResponse;
+import com.jian.hobbyadventure.service.CategoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoryController.class)
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @Test
+    void getCategories_성공_시_200을_반환한다() throws Exception {
+        List<CategoryResponse> categories = List.of(
+                new CategoryResponse(1L, "EXERCISE", "운동"),
+                new CategoryResponse(2L, "VISIT", "방문")
+        );
+        when(categoryService.getCategories()).thenReturn(categories);
+
+        mockMvc.perform(get("/api/v1/categories"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].code").value("EXERCISE"))
+                .andExpect(jsonPath("$.data[0].name").value("운동"));
+    }
+
+    @Test
+    void getCategories_데이터가_없을_때_빈_배열을_반환한다() throws Exception {
+        when(categoryService.getCategories()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/categories"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/com/jian/hobbyadventure/service/CategoryServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/CategoryServiceTest.java
@@ -1,0 +1,49 @@
+package com.jian.hobbyadventure.service;
+
+import com.jian.hobbyadventure.domain.Category;
+import com.jian.hobbyadventure.dto.response.CategoryResponse;
+import com.jian.hobbyadventure.repository.CategoryMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    void getCategories_카테고리_목록을_반환한다() {
+        List<Category> categories = List.of(
+                new Category(1L, "EXERCISE", "운동", 1),
+                new Category(2L, "VISIT", "방문", 2)
+        );
+        when(categoryMapper.findAll()).thenReturn(categories);
+
+        List<CategoryResponse> result = categoryService.getCategories();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCode()).isEqualTo("EXERCISE");
+        assertThat(result.get(0).getName()).isEqualTo("운동");
+    }
+
+    @Test
+    void getCategories_데이터가_없으면_빈_리스트를_반환한다() {
+        when(categoryMapper.findAll()).thenReturn(List.of());
+
+        List<CategoryResponse> result = categoryService.getCategories();
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -9,3 +9,14 @@ CREATE TABLE users
     CONSTRAINT uk_users_email UNIQUE (email),
     CONSTRAINT uk_users_nickname UNIQUE (nickname)
 );
+
+CREATE TABLE categories
+(
+    category_id   BIGINT      NOT NULL AUTO_INCREMENT,
+    code          VARCHAR(50) NOT NULL,
+    name          VARCHAR(50) NOT NULL,
+    display_order INT         NOT NULL,
+    PRIMARY KEY (category_id),
+    CONSTRAINT uk_categories_code UNIQUE (code),
+    CONSTRAINT uk_categories_display_order UNIQUE (display_order)
+);


### PR DESCRIPTION
## 개요
탐험 카테고리 목록을 조회하는 API를 구현했습니다.

## Issue
- #13

## 구현 내용
- 카테고리 조회 API 구현
- 카테고리 목록 조회 로직 작성
- Response DTO 변환 로직 적용
- 테스트 코드 작성
- Swagger API 문서 작성

## Done
- 카테고리 목록 조회 API가 정상 동작합니다.
- 요청 시 카테고리 리스트를 반환합니다.
- 테스트 코드가 정상 동작합니다.
- Swagger에서 API 확인이 가능합니다.

## 리뷰 시 참고 사항

### 1. SELECT * 사용 여부
- `SELECT *` 대신 필요한 컬럼만 명시적으로 조회하도록 구성했습니다.  
- 컬럼 변경 시 의도하지 않은 데이터 조회를 방지하고, 가독성을 높이기 위함입니다.

### 2. DTO 변환 시 성능 고려
- Domain → DTO 변환 과정에서 객체와 리스트가 새로 생성됩니다.  
- 카테고리는 소량 데이터이므로 성능보다 계층 분리를 우선했습니다.  
- 데이터 증가 시에는 페이징, 필요한 컬럼 조회, DTO 직접 매핑 등을 고려할 수 있습니다.

### 3. List 인터페이스 사용
- 반환 타입으로 `ArrayList` 대신 `List` 인터페이스를 사용했습니다.  
- 구현체에 대한 의존을 줄이고, 내부 변경에 유연하게 대응하기 위함입니다.

### 4. 카테고리 ENUM vs 테이블 설계
- 카테고리를 ENUM이 아닌 DB 테이블로 관리했습니다.  
- 추후 카테고리 기반 조회 및 확장성을 고려하여 관계형 구조를 선택했습니다.

## 리뷰 요청

아래 설계 방향에 대해 의견 부탁드립니다.

1. 카테고리 조회 시 명시적 컬럼 조회 방식이 적절한지
2. Domain → DTO 변환 구조가 현재 규모에서 적절한지
3. List 인터페이스 반환 방식이 적절한지
4. 카테고리를 ENUM이 아닌 테이블로 관리한 선택이 적절한지

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 관련 issue와 연결했습니다.
- [x] 셀프 리뷰를 진행했습니다.
- [x] 테스트를 통해 정상 동작을 확인했습니다.