### PR TITLE
사용자 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/jian/hobbyadventure/controller/UserController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/UserController.java
@@ -29,6 +29,11 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "사용자 정보 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class)), description = "존재하지 않는 사용자")
+    })
     @GetMapping("/{userId}")
     public ResponseEntity<CommonResponse<UserProfileResponse>> getUserProfile(@PathVariable Long userId) {
         UserProfileResponse response = userService.getUserProfile(userId);

--- a/src/main/java/com/jian/hobbyadventure/controller/UserController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/UserController.java
@@ -3,6 +3,7 @@ package com.jian.hobbyadventure.controller;
 import com.jian.hobbyadventure.common.response.CommonResponse;
 import com.jian.hobbyadventure.common.response.ErrorResponse;
 import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
+import com.jian.hobbyadventure.dto.response.UserProfileResponse;
 import com.jian.hobbyadventure.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +28,12 @@ import static org.springframework.http.HttpStatus.OK;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<CommonResponse<UserProfileResponse>> getUserProfile(@PathVariable Long userId) {
+        UserProfileResponse response = userService.getUserProfile(userId);
+        return ResponseEntity.ok(CommonResponse.of(response));
+    }
 
     @Operation(summary = "회원탈퇴")
     @ApiResponses({

--- a/src/main/java/com/jian/hobbyadventure/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package com.jian.hobbyadventure.dto.response;
+
+import com.jian.hobbyadventure.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileResponse {
+
+    private final Long userId;
+    private final String email;
+    private final String nickname;
+
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(user.getUserId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/UserProfileResponse.java
@@ -1,15 +1,22 @@
 package com.jian.hobbyadventure.dto.response;
 
 import com.jian.hobbyadventure.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Schema(description = "사용자 정보 조회 응답")
 @Getter
 @AllArgsConstructor
 public class UserProfileResponse {
 
+    @Schema(description = "사용자 ID", example = "1")
     private final Long userId;
+
+    @Schema(description = "이메일", example = "user@example.com")
     private final String email;
+
+    @Schema(description = "닉네임", example = "홍길동")
     private final String nickname;
 
     public static UserProfileResponse from(User user) {

--- a/src/main/java/com/jian/hobbyadventure/service/UserService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/UserService.java
@@ -7,6 +7,7 @@ import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
 import com.jian.hobbyadventure.dto.response.LoginResponse;
+import com.jian.hobbyadventure.dto.response.UserProfileResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
@@ -19,6 +20,12 @@ public class UserService {
 
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
+
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userMapper.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        return UserProfileResponse.from(user);
+    }
 
     public DeleteAccountResponse deleteAccount(Long userId) {
         userMapper.findById(userId)

--- a/src/test/java/com/jian/hobbyadventure/controller/UserControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.jian.hobbyadventure.controller;
 import com.jian.hobbyadventure.common.exception.BusinessException;
 import com.jian.hobbyadventure.common.exception.ErrorCode;
 import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
+import com.jian.hobbyadventure.dto.response.UserProfileResponse;
 import com.jian.hobbyadventure.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -24,6 +26,28 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @Test
+    void getUserProfile_성공_시_200_응답을_반환한다() throws Exception {
+        when(userService.getUserProfile(1L))
+                .thenReturn(new UserProfileResponse(1L, "test@example.com", "닉네임"));
+
+        mockMvc.perform(get("/api/v1/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.nickname").value("닉네임"));
+    }
+
+    @Test
+    void getUserProfile_존재하지_않는_userId_시_404를_반환한다() throws Exception {
+        doThrow(new BusinessException(ErrorCode.NOT_FOUND))
+                .when(userService).getUserProfile(1L);
+
+        mockMvc.perform(get("/api/v1/users/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("요청하신 정보를 찾을 수 없습니다."));
+    }
 
     @Test
     void deleteAccount_성공_시_200_응답을_반환한다() throws Exception {

--- a/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.jian.hobbyadventure.dto.request.LoginRequest;
 import com.jian.hobbyadventure.dto.request.SignupRequest;
 import com.jian.hobbyadventure.dto.response.DeleteAccountResponse;
 import com.jian.hobbyadventure.dto.response.LoginResponse;
+import com.jian.hobbyadventure.dto.response.UserProfileResponse;
 import com.jian.hobbyadventure.repository.UserMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,28 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Test
+    void getUserProfile_성공_시_userId_email_nickname을_반환한다() {
+        User user = new User(1L, "test@example.com", "encodedPassword", "닉네임", LocalDateTime.now());
+        when(userMapper.findById(1L)).thenReturn(Optional.of(user));
+
+        UserProfileResponse response = userService.getUserProfile(1L);
+
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getEmail()).isEqualTo("test@example.com");
+        assertThat(response.getNickname()).isEqualTo("닉네임");
+    }
+
+    @Test
+    void getUserProfile_존재하지_않는_userId_시_BusinessException을_던진다() {
+        when(userMapper.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getUserProfile(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
 
     @Test
     void deleteAccount_성공_시_success가_true를_반환한다() {


### PR DESCRIPTION
## 개요

사용자 식별자를 기반으로 사용자 정보를 조회하는 기능을 구현했습니다.

## Issue
#15 

## 구현 내용

- 사용자 정보 조회 API 구현
- 사용자 정보 조회 로직 구현
- 사용자 정보 Response DTO 작성
- 사용자 정보 조회 테스트 코드 작성
- Swagger API 문서 작성

## Done

- 사용자 식별자를 기반으로 사용자 정보를 조회할 수 있습니다.
- 조회 응답에 비밀번호가 포함되지 않습니다.
- 요청 시 정상 응답을 반환합니다.
- 테스트 코드가 정상 동작합니다.
- Swagger에서 API 확인이 가능합니다.

## 리뷰 시 참고 사항

현재는 사용자 식별자를 기반으로 조회하는 방식으로 구현했습니다.

## 리뷰 요청

- 사용자 정보 조회 API 응답 구조가 적절한지 확인 부탁드립니다.
- email을 응답값에 포함한 부분이 적절한지 확인 부탁드립니다.

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 관련 issue와 연결했습니다.
- [x] 셀프 리뷰를 진행했습니다.
- [x] 테스트를 통해 정상 동작을 확인했습니다.