### PR TITLE
기록 API 구현 

### DIFF
--- a/db/mysql/init/01_ddl.sql
+++ b/db/mysql/init/01_ddl.sql
@@ -48,3 +48,30 @@ CREATE TABLE user_explorations
     CONSTRAINT fk_user_explorations_user FOREIGN KEY (user_id) REFERENCES users (user_id),
     CONSTRAINT fk_user_explorations_exploration FOREIGN KEY (exploration_id) REFERENCES explorations (id)
 );
+
+CREATE TABLE records
+(
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    user_exploration_id BIGINT       NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    visited_date        DATE         NOT NULL,
+    rating              TINYINT      NOT NULL,
+    emotion_code        VARCHAR(30)  NOT NULL,
+    place_name          VARCHAR(255),
+    content             TEXT         NOT NULL,
+    created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_records_user_exploration FOREIGN KEY (user_exploration_id) REFERENCES user_explorations (id)
+);
+
+CREATE TABLE record_images
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    record_id   BIGINT       NOT NULL,
+    image_url   VARCHAR(500) NOT NULL,
+    image_order INT          NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_record_images_record FOREIGN KEY (record_id) REFERENCES records (id)
+);

--- a/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
+++ b/src/main/java/com/jian/hobbyadventure/common/exception/ErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 값입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
@@ -10,6 +10,9 @@ import com.jian.hobbyadventure.dto.response.RecordDetailResponse;
 import com.jian.hobbyadventure.dto.response.RecordListItemResponse;
 import com.jian.hobbyadventure.dto.response.UpdateRecordResponse;
 import com.jian.hobbyadventure.service.RecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -28,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "Record", description = "기록 API")
 @RestController
 @RequestMapping("/api/v1/records")
 @RequiredArgsConstructor
@@ -35,6 +39,8 @@ public class RecordController {
 
     private final RecordService recordService;
 
+    @Operation(summary = "기록 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공 (데이터 없을 경우 빈 배열 반환)")
     @GetMapping
     public ResponseEntity<PageResponse<RecordListItemResponse>> getRecords(
             @RequestHeader("X-User-Id") Long userId,
@@ -45,6 +51,8 @@ public class RecordController {
         return ResponseEntity.ok(recordService.getRecords(userId, categoryId, explorationId, page, size));
     }
 
+    @Operation(summary = "기록 단건 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/{recordId}")
     public ResponseEntity<CommonResponse<RecordDetailResponse>> getRecord(
             @RequestHeader("X-User-Id") Long userId,
@@ -52,6 +60,8 @@ public class RecordController {
         return ResponseEntity.ok(CommonResponse.of(recordService.getRecord(userId, recordId)));
     }
 
+    @Operation(summary = "기록 생성")
+    @ApiResponse(responseCode = "201", description = "기록 생성 성공")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<CreateRecordResponse>> createRecord(
             @RequestHeader("X-User-Id") Long userId,
@@ -60,6 +70,8 @@ public class RecordController {
         return ResponseEntity.status(201).body(CommonResponse.of(recordService.createRecord(userId, request, images)));
     }
 
+    @Operation(summary = "기록 수정")
+    @ApiResponse(responseCode = "200", description = "기록 수정 성공")
     @PatchMapping(value = "/{recordId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<UpdateRecordResponse>> updateRecord(
             @RequestHeader("X-User-Id") Long userId,
@@ -69,6 +81,8 @@ public class RecordController {
         return ResponseEntity.ok(CommonResponse.of(recordService.updateRecord(userId, recordId, request, images)));
     }
 
+    @Operation(summary = "기록 삭제")
+    @ApiResponse(responseCode = "200", description = "기록 삭제 성공")
     @DeleteMapping("/{recordId}")
     public ResponseEntity<CommonResponse<DeleteRecordResponse>> deleteRecord(
             @RequestHeader("X-User-Id") Long userId,

--- a/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
@@ -3,6 +3,7 @@ package com.jian.hobbyadventure.controller;
 import com.jian.hobbyadventure.common.response.CommonResponse;
 import com.jian.hobbyadventure.common.response.PageResponse;
 import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.RecordSearchCondition;
 import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
 import com.jian.hobbyadventure.dto.response.CreateRecordResponse;
 import com.jian.hobbyadventure.dto.response.DeleteRecordResponse;
@@ -48,7 +49,8 @@ public class RecordController {
             @RequestParam(required = false) Long explorationId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
-        return ResponseEntity.ok(recordService.getRecords(userId, categoryId, explorationId, page, size));
+        RecordSearchCondition condition = new RecordSearchCondition(categoryId, explorationId);
+        return ResponseEntity.ok(recordService.getRecords(userId, condition, page, size));
     }
 
     @Operation(summary = "기록 단건 조회")

--- a/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
+++ b/src/main/java/com/jian/hobbyadventure/controller/RecordController.java
@@ -1,0 +1,78 @@
+package com.jian.hobbyadventure.controller;
+
+import com.jian.hobbyadventure.common.response.CommonResponse;
+import com.jian.hobbyadventure.common.response.PageResponse;
+import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
+import com.jian.hobbyadventure.dto.response.CreateRecordResponse;
+import com.jian.hobbyadventure.dto.response.DeleteRecordResponse;
+import com.jian.hobbyadventure.dto.response.RecordDetailResponse;
+import com.jian.hobbyadventure.dto.response.RecordListItemResponse;
+import com.jian.hobbyadventure.dto.response.UpdateRecordResponse;
+import com.jian.hobbyadventure.service.RecordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/records")
+@RequiredArgsConstructor
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<RecordListItemResponse>> getRecords(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) Long explorationId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(recordService.getRecords(userId, categoryId, explorationId, page, size));
+    }
+
+    @GetMapping("/{recordId}")
+    public ResponseEntity<CommonResponse<RecordDetailResponse>> getRecord(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long recordId) {
+        return ResponseEntity.ok(CommonResponse.of(recordService.getRecord(userId, recordId)));
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CommonResponse<CreateRecordResponse>> createRecord(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestPart("request") @Valid CreateRecordRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        return ResponseEntity.status(201).body(CommonResponse.of(recordService.createRecord(userId, request, images)));
+    }
+
+    @PatchMapping(value = "/{recordId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CommonResponse<UpdateRecordResponse>> updateRecord(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long recordId,
+            @RequestPart("request") @Valid UpdateRecordRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        return ResponseEntity.ok(CommonResponse.of(recordService.updateRecord(userId, recordId, request, images)));
+    }
+
+    @DeleteMapping("/{recordId}")
+    public ResponseEntity<CommonResponse<DeleteRecordResponse>> deleteRecord(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long recordId) {
+        return ResponseEntity.ok(CommonResponse.of(recordService.deleteRecord(userId, recordId)));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/domain/Emotion.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/Emotion.java
@@ -1,0 +1,24 @@
+package com.jian.hobbyadventure.domain;
+
+public enum Emotion {
+
+    PROUD("뿌듯"),
+    HAPPY("행복"),
+    EXCITED("신남"),
+    TOUCHED("감동"),
+    CALM("평온"),
+    BITTERSWEET("아쉬움"),
+    DIFFICULT("힘들었어"),
+    LONELY("외로움"),
+    DISAPPOINTED("실망");
+
+    private final String label;
+
+    Emotion(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/domain/Record.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/Record.java
@@ -17,7 +17,7 @@ public class Record extends BaseEntity {
     private String title;
     private LocalDate visitedDate;
     private int rating;
-    private Emotion emotion;
+    private Emotion emotionCode;
     private String placeName;
     private String content;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/jian/hobbyadventure/domain/Record.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/Record.java
@@ -21,4 +21,17 @@ public class Record extends BaseEntity {
     private String placeName;
     private String content;
     private LocalDateTime updatedAt;
+
+    public static Record create(Long userExplorationId, String title, LocalDate visitedDate,
+                                int rating, Emotion emotionCode, String placeName, String content) {
+        Record record = new Record();
+        record.setUserExplorationId(userExplorationId);
+        record.setTitle(title);
+        record.setVisitedDate(visitedDate);
+        record.setRating(rating);
+        record.setEmotionCode(emotionCode);
+        record.setPlaceName(placeName);
+        record.setContent(content);
+        return record;
+    }
 }

--- a/src/main/java/com/jian/hobbyadventure/domain/Record.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/Record.java
@@ -1,0 +1,24 @@
+package com.jian.hobbyadventure.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Record extends BaseEntity {
+
+    private Long id;
+    private Long userExplorationId;
+    private String title;
+    private LocalDate visitedDate;
+    private int rating;
+    private Emotion emotion;
+    private String placeName;
+    private String content;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/jian/hobbyadventure/domain/RecordImage.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/RecordImage.java
@@ -1,0 +1,16 @@
+package com.jian.hobbyadventure.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordImage extends BaseEntity {
+
+    private Long id;
+    private Long recordId;
+    private String imageUrl;
+    private int imageOrder;
+}

--- a/src/main/java/com/jian/hobbyadventure/domain/UserExploration.java
+++ b/src/main/java/com/jian/hobbyadventure/domain/UserExploration.java
@@ -25,9 +25,4 @@ public class UserExploration extends BaseEntity {
         return ue;
     }
 
-    // TODO: 기록 기능 미구현으로 false 고정. 기록 기능 추가 시 실제 기록 보유 여부를 반환하도록 변경
-    public Boolean hasRecord() {
-        if (this.status != ExplorationStatus.COMPLETED) return null;
-        return false;
-    }
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/request/CreateRecordRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/CreateRecordRequest.java
@@ -1,0 +1,40 @@
+package com.jian.hobbyadventure.dto.request;
+
+import com.jian.hobbyadventure.domain.Emotion;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateRecordRequest {
+
+    @NotNull(message = "내 탐험 ID를 입력해주세요.")
+    private Long userExplorationId;
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    private String title;
+
+    @NotNull(message = "방문 날짜를 입력해주세요.")
+    private LocalDate visitedDate;
+
+    @NotNull(message = "별점을 입력해주세요.")
+    @Min(value = 1, message = "별점은 1 이상이어야 합니다.")
+    @Max(value = 5, message = "별점은 5 이하여야 합니다.")
+    private Integer rating;
+
+    @NotNull(message = "감정을 선택해주세요.")
+    private Emotion emotionCode;
+
+    private String placeName;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/request/RecordSearchCondition.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/RecordSearchCondition.java
@@ -1,0 +1,23 @@
+package com.jian.hobbyadventure.dto.request;
+
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
+
+public record RecordSearchCondition(
+        Long categoryId,
+        Long explorationId
+) {
+    public RecordSearchCondition {
+        if (categoryId != null && explorationId != null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    public boolean hasCategoryFilter() {
+        return categoryId != null;
+    }
+
+    public boolean hasExplorationFilter() {
+        return explorationId != null;
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/request/UpdateRecordRequest.java
@@ -1,0 +1,27 @@
+package com.jian.hobbyadventure.dto.request;
+
+import com.jian.hobbyadventure.domain.Emotion;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateRecordRequest {
+
+    private String title;
+    private LocalDate visitedDate;
+
+    @Min(value = 1, message = "별점은 1 이상이어야 합니다.")
+    @Max(value = 5, message = "별점은 5 이하여야 합니다.")
+    private Integer rating;
+
+    private Emotion emotionCode;
+    private String placeName;
+    private String content;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/CreateRecordResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/CreateRecordResponse.java
@@ -1,0 +1,11 @@
+package com.jian.hobbyadventure.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateRecordResponse {
+
+    private final Long recordId;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/DeleteRecordResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/DeleteRecordResponse.java
@@ -1,0 +1,11 @@
+package com.jian.hobbyadventure.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteRecordResponse {
+
+    private final Long recordId;
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/MyExplorationDetailResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/MyExplorationDetailResponse.java
@@ -25,7 +25,7 @@ public class MyExplorationDetailResponse {
     private final Boolean hasRecord;
     private final Long recordId;
 
-    public static MyExplorationDetailResponse from(UserExploration ue, Exploration e, String categoryName, String imageBaseUrl) {
+    public static MyExplorationDetailResponse from(UserExploration ue, Exploration e, String categoryName, String imageBaseUrl, Boolean hasRecord, Long recordId) {
         String thumbnailUrl = e.getThumbnailUrl() != null ? imageBaseUrl + e.getThumbnailUrl() : null;
         return new MyExplorationDetailResponse(
                 ue.getId(),
@@ -38,8 +38,8 @@ public class MyExplorationDetailResponse {
                 ue.getStatus(),
                 ue.getCreatedAt(),
                 ue.getCompletedAt(),
-                ue.hasRecord(),
-                null
+                hasRecord,
+                recordId
         );
     }
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/response/MyExplorationListItemResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/MyExplorationListItemResponse.java
@@ -24,7 +24,7 @@ public class MyExplorationListItemResponse {
     private final LocalDateTime completedAt;
     private final Boolean hasRecord;
 
-    public static MyExplorationListItemResponse from(UserExploration ue, Exploration e, String categoryName, String imageBaseUrl) {
+    public static MyExplorationListItemResponse from(UserExploration ue, Exploration e, String categoryName, String imageBaseUrl, Boolean hasRecord) {
         String thumbnailUrl = e.getThumbnailUrl() != null ? imageBaseUrl + e.getThumbnailUrl() : null;
         return new MyExplorationListItemResponse(
                 ue.getId(),
@@ -37,7 +37,7 @@ public class MyExplorationListItemResponse {
                 ue.getStatus(),
                 ue.getCreatedAt(),
                 ue.getCompletedAt(),
-                ue.hasRecord()
+                hasRecord
         );
     }
 }

--- a/src/main/java/com/jian/hobbyadventure/dto/response/RecordDetailResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/RecordDetailResponse.java
@@ -1,0 +1,55 @@
+package com.jian.hobbyadventure.dto.response;
+
+import com.jian.hobbyadventure.domain.Exploration;
+import com.jian.hobbyadventure.domain.Record;
+import com.jian.hobbyadventure.domain.UserExploration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RecordDetailResponse {
+
+    private final Long recordId;
+    private final Long userExplorationId;
+    private final Long explorationId;
+    private final String explorationTitle;
+    private final Long categoryId;
+    private final String categoryName;
+    private final String title;
+    private final LocalDate visitedDate;
+    private final int rating;
+    private final String emotionCode;
+    private final String emotionLabel;
+    private final String placeName;
+    private final String content;
+    private final List<String> imageUrls;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static RecordDetailResponse from(Record record, UserExploration ue, Exploration exploration,
+                                            String categoryName, List<String> imageUrls) {
+        return new RecordDetailResponse(
+                record.getId(),
+                ue.getId(),
+                exploration.getId(),
+                exploration.getTitle(),
+                exploration.getCategoryId(),
+                categoryName,
+                record.getTitle(),
+                record.getVisitedDate(),
+                record.getRating(),
+                record.getEmotionCode().name(),
+                record.getEmotionCode().getLabel(),
+                record.getPlaceName(),
+                record.getContent(),
+                imageUrls,
+                record.getCreatedAt(),
+                record.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/RecordListItemResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/RecordListItemResponse.java
@@ -1,0 +1,48 @@
+package com.jian.hobbyadventure.dto.response;
+
+import com.jian.hobbyadventure.domain.Exploration;
+import com.jian.hobbyadventure.domain.Record;
+import com.jian.hobbyadventure.domain.UserExploration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RecordListItemResponse {
+
+    private final Long recordId;
+    private final Long userExplorationId;
+    private final Long explorationId;
+    private final String explorationTitle;
+    private final Long categoryId;
+    private final String categoryName;
+    private final String title;
+    private final String thumbnailUrl;
+    private final LocalDate visitedDate;
+    private final int rating;
+    private final String emotionCode;
+    private final String emotionLabel;
+    private final LocalDateTime createdAt;
+
+    public static RecordListItemResponse from(Record record, UserExploration ue, Exploration exploration,
+                                              String categoryName, String thumbnailUrl) {
+        return new RecordListItemResponse(
+                record.getId(),
+                ue.getId(),
+                exploration.getId(),
+                exploration.getTitle(),
+                exploration.getCategoryId(),
+                categoryName,
+                record.getTitle(),
+                thumbnailUrl,
+                record.getVisitedDate(),
+                record.getRating(),
+                record.getEmotionCode().name(),
+                record.getEmotionCode().getLabel(),
+                record.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/dto/response/UpdateRecordResponse.java
+++ b/src/main/java/com/jian/hobbyadventure/dto/response/UpdateRecordResponse.java
@@ -1,0 +1,11 @@
+package com.jian.hobbyadventure.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateRecordResponse {
+
+    private final Long recordId;
+}

--- a/src/main/java/com/jian/hobbyadventure/repository/RecordImageMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/RecordImageMapper.java
@@ -1,0 +1,29 @@
+package com.jian.hobbyadventure.repository;
+
+import com.jian.hobbyadventure.domain.RecordImage;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface RecordImageMapper {
+
+    @Insert("<script>INSERT INTO record_images (record_id, image_url, image_order) VALUES " +
+            "<foreach collection='images' item='img' separator=','>(#{img.recordId}, #{img.imageUrl}, #{img.imageOrder})</foreach></script>")
+    void insertAll(@Param("images") List<RecordImage> images);
+
+    @Select("SELECT * FROM record_images WHERE record_id = #{recordId} ORDER BY image_order ASC")
+    List<RecordImage> findAllByRecordId(Long recordId);
+
+    @Select("<script>SELECT * FROM record_images WHERE record_id IN " +
+            "<foreach collection='recordIds' item='id' open='(' separator=',' close=')'>#{id}</foreach>" +
+            " ORDER BY image_order ASC</script>")
+    List<RecordImage> findAllByRecordIds(@Param("recordIds") List<Long> recordIds);
+
+    @Delete("DELETE FROM record_images WHERE record_id = #{recordId}")
+    void deleteAllByRecordId(Long recordId);
+}

--- a/src/main/java/com/jian/hobbyadventure/repository/RecordMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/RecordMapper.java
@@ -51,6 +51,10 @@ public interface RecordMapper {
             """)
     void update(Record record);
 
+    @Select("<script>SELECT user_exploration_id FROM records WHERE user_exploration_id IN " +
+            "<foreach collection='userExplorationIds' item='id' open='(' separator=',' close=')'>#{id}</foreach></script>")
+    List<Long> findUserExplorationIdsByUserExplorationIdIn(@Param("userExplorationIds") List<Long> userExplorationIds);
+
     @Delete("DELETE FROM records WHERE id = #{id}")
     void deleteById(Long id);
 }

--- a/src/main/java/com/jian/hobbyadventure/repository/RecordMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/RecordMapper.java
@@ -1,0 +1,56 @@
+package com.jian.hobbyadventure.repository;
+
+import com.jian.hobbyadventure.domain.Record;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface RecordMapper {
+
+    @Insert("""
+            INSERT INTO records (user_exploration_id, title, visited_date, rating, emotion_code, place_name, content)
+            VALUES (#{userExplorationId}, #{title}, #{visitedDate}, #{rating}, #{emotionCode}, #{placeName}, #{content})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insert(Record record);
+
+    @Select("SELECT * FROM records WHERE id = #{id}")
+    Optional<Record> findById(Long id);
+
+    @Select("SELECT * FROM records WHERE user_exploration_id = #{userExplorationId}")
+    Optional<Record> findByUserExplorationId(Long userExplorationId);
+
+    @Select("SELECT EXISTS(SELECT 1 FROM records WHERE user_exploration_id = #{userExplorationId})")
+    boolean existsByUserExplorationId(Long userExplorationId);
+
+    @Select("<script>SELECT * FROM records WHERE user_exploration_id IN " +
+            "<foreach collection='userExplorationIds' item='id' open='(' separator=',' close=')'>#{id}</foreach>" +
+            " ORDER BY created_at DESC LIMIT #{size} OFFSET #{offset}</script>")
+    List<Record> findAllByUserExplorationIds(@Param("userExplorationIds") List<Long> userExplorationIds,
+                                             @Param("size") int size,
+                                             @Param("offset") int offset);
+
+    @Select("<script>SELECT COUNT(*) FROM records WHERE user_exploration_id IN " +
+            "<foreach collection='userExplorationIds' item='id' open='(' separator=',' close=')'>#{id}</foreach></script>")
+    long countByUserExplorationIds(@Param("userExplorationIds") List<Long> userExplorationIds);
+
+    @Update("""
+            UPDATE records
+            SET title = #{title}, visited_date = #{visitedDate}, rating = #{rating},
+                emotion_code = #{emotionCode}, place_name = #{placeName}, content = #{content},
+                updated_at = NOW()
+            WHERE id = #{id}
+            """)
+    void update(Record record);
+
+    @Delete("DELETE FROM records WHERE id = #{id}")
+    void deleteById(Long id);
+}

--- a/src/main/java/com/jian/hobbyadventure/repository/UserExplorationMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/UserExplorationMapper.java
@@ -45,4 +45,8 @@ public interface UserExplorationMapper {
     @Select("<script>SELECT id FROM user_explorations WHERE user_id = #{userId} AND exploration_id IN " +
             "<foreach collection='explorationIds' item='id' open='(' separator=',' close=')'>#{id}</foreach></script>")
     List<Long> findIdsByUserIdAndExplorationIds(@Param("userId") Long userId, @Param("explorationIds") List<Long> explorationIds);
+
+    @Select("<script>SELECT * FROM user_explorations WHERE id IN " +
+            "<foreach collection='ids' item='id' open='(' separator=',' close=')'>#{id}</foreach></script>")
+    List<UserExploration> findByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/jian/hobbyadventure/repository/UserExplorationMapper.java
+++ b/src/main/java/com/jian/hobbyadventure/repository/UserExplorationMapper.java
@@ -38,4 +38,11 @@ public interface UserExplorationMapper {
 
     @Update("UPDATE user_explorations SET status = 'COMPLETED', completed_at = NOW() WHERE id = #{id}")
     void complete(Long id);
+
+    @Select("SELECT id FROM user_explorations WHERE user_id = #{userId}")
+    List<Long> findIdsByUserId(Long userId);
+
+    @Select("<script>SELECT id FROM user_explorations WHERE user_id = #{userId} AND exploration_id IN " +
+            "<foreach collection='explorationIds' item='id' open='(' separator=',' close=')'>#{id}</foreach></script>")
+    List<Long> findIdsByUserIdAndExplorationIds(@Param("userId") Long userId, @Param("explorationIds") List<Long> explorationIds);
 }

--- a/src/main/java/com/jian/hobbyadventure/service/ImageService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/ImageService.java
@@ -1,0 +1,59 @@
+package com.jian.hobbyadventure.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ImageService {
+
+    @Value("${app.image.upload-path}")
+    private String uploadPath;
+
+    public List<String> saveImages(Long recordId, List<MultipartFile> files) {
+        List<String> relativePaths = new ArrayList<>();
+        for (MultipartFile file : files) {
+            String ext = extractExtension(file.getOriginalFilename());
+            String filename = UUID.randomUUID() + ext;
+            String relativePath = "records/" + recordId + "/" + filename;
+            Path targetPath = Paths.get(uploadPath).resolve(relativePath);
+            try {
+                Files.createDirectories(targetPath.getParent());
+                Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                throw new RuntimeException("파일 저장 실패: " + filename, e);
+            }
+            relativePaths.add(relativePath);
+        }
+        return relativePaths;
+    }
+
+    public void deleteImages(Long recordId) {
+        Path dir = Paths.get(uploadPath).resolve("records").resolve(recordId.toString());
+        if (!Files.exists(dir)) return;
+        try (var stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException ignored) {
+                }
+            });
+        } catch (IOException ignored) {
+        }
+    }
+
+    private String extractExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) return "";
+        return originalFilename.substring(originalFilename.lastIndexOf('.'));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/service/MyExplorationService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/MyExplorationService.java
@@ -5,6 +5,7 @@ import com.jian.hobbyadventure.common.response.PageResponse;
 import com.jian.hobbyadventure.domain.Category;
 import com.jian.hobbyadventure.domain.Exploration;
 import com.jian.hobbyadventure.domain.ExplorationStatus;
+import com.jian.hobbyadventure.domain.Record;
 import com.jian.hobbyadventure.domain.UserExploration;
 import com.jian.hobbyadventure.common.exception.BusinessException;
 import com.jian.hobbyadventure.common.exception.ErrorCode;
@@ -13,13 +14,16 @@ import com.jian.hobbyadventure.dto.response.MyExplorationDetailResponse;
 import com.jian.hobbyadventure.dto.response.MyExplorationListItemResponse;
 import com.jian.hobbyadventure.repository.CategoryMapper;
 import com.jian.hobbyadventure.repository.ExplorationMapper;
+import com.jian.hobbyadventure.repository.RecordMapper;
 import com.jian.hobbyadventure.repository.UserExplorationMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,6 +33,7 @@ public class MyExplorationService {
     private final UserExplorationMapper userExplorationMapper;
     private final ExplorationMapper explorationMapper;
     private final CategoryMapper categoryMapper;
+    private final RecordMapper recordMapper;
 
     @Value("${app.image.base-url}")
     private String imageBaseUrl;
@@ -51,11 +56,16 @@ public class MyExplorationService {
         Map<Long, String> categoryNameMap = categoryMapper.findAll().stream()
                 .collect(Collectors.toMap(Category::getCategoryId, Category::getName));
 
+        List<Long> ueIds = userExplorations.stream().map(UserExploration::getId).toList();
+        Set<Long> hasRecordSet = ueIds.isEmpty() ? Set.of() :
+                new HashSet<>(recordMapper.findUserExplorationIdsByUserExplorationIdIn(ueIds));
+
         List<MyExplorationListItemResponse> data = userExplorations.stream()
                 .map(ue -> {
                     Exploration e = explorationMap.get(ue.getExplorationId());
                     String categoryName = categoryNameMap.get(e.getCategoryId());
-                    return MyExplorationListItemResponse.from(ue, e, categoryName, imageBaseUrl);
+                    Boolean hasRecord = ue.getStatus() == ExplorationStatus.COMPLETED ? hasRecordSet.contains(ue.getId()) : null;
+                    return MyExplorationListItemResponse.from(ue, e, categoryName, imageBaseUrl, hasRecord);
                 })
                 .toList();
 
@@ -75,7 +85,11 @@ public class MyExplorationService {
 
         Category category = categoryMapper.findById(exploration.getCategoryId());
 
-        return MyExplorationDetailResponse.from(userExploration, exploration, category.getName(), imageBaseUrl);
+        Record record = recordMapper.findByUserExplorationId(userExplorationId).orElse(null);
+        Boolean hasRecord = userExploration.getStatus() == ExplorationStatus.COMPLETED ? record != null : null;
+        Long recordId = record != null ? record.getId() : null;
+
+        return MyExplorationDetailResponse.from(userExploration, exploration, category.getName(), imageBaseUrl, hasRecord, recordId);
     }
 
     public CompleteExplorationResponse completeExploration(Long userId, Long userExplorationId) {

--- a/src/main/java/com/jian/hobbyadventure/service/MyExplorationService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/MyExplorationService.java
@@ -64,7 +64,7 @@ public class MyExplorationService {
                 .map(ue -> {
                     Exploration e = explorationMap.get(ue.getExplorationId());
                     String categoryName = categoryNameMap.get(e.getCategoryId());
-                    Boolean hasRecord = ue.getStatus() == ExplorationStatus.COMPLETED ? hasRecordSet.contains(ue.getId()) : null;
+                    Boolean hasRecord = toHasRecord(ue.getStatus(), hasRecordSet.contains(ue.getId()));
                     return MyExplorationListItemResponse.from(ue, e, categoryName, imageBaseUrl, hasRecord);
                 })
                 .toList();
@@ -86,10 +86,14 @@ public class MyExplorationService {
         Category category = categoryMapper.findById(exploration.getCategoryId());
 
         Record record = recordMapper.findByUserExplorationId(userExplorationId).orElse(null);
-        Boolean hasRecord = userExploration.getStatus() == ExplorationStatus.COMPLETED ? record != null : null;
+        Boolean hasRecord = toHasRecord(userExploration.getStatus(), record != null);
         Long recordId = record != null ? record.getId() : null;
 
         return MyExplorationDetailResponse.from(userExploration, exploration, category.getName(), imageBaseUrl, hasRecord, recordId);
+    }
+
+    private Boolean toHasRecord(ExplorationStatus status, boolean recordExists) {
+        return status == ExplorationStatus.COMPLETED ? recordExists : null;
     }
 
     public CompleteExplorationResponse completeExploration(Long userId, Long userExplorationId) {

--- a/src/main/java/com/jian/hobbyadventure/service/RecordService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/RecordService.java
@@ -86,17 +86,7 @@ public class RecordService {
     public PageResponse<RecordListItemResponse> getRecords(Long userId, Long categoryId, Long explorationId, int page, int size) {
         int offset = (page - 1) * size;
 
-        List<Long> userExplorationIds;
-        if (explorationId != null) {
-            userExplorationIds = userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, List.of(explorationId));
-        } else if (categoryId != null) {
-            List<Long> explorationIds = explorationMapper.findIdsByCategoryId(categoryId);
-            userExplorationIds = explorationIds.isEmpty()
-                    ? List.of()
-                    : userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, explorationIds);
-        } else {
-            userExplorationIds = userExplorationMapper.findIdsByUserId(userId);
-        }
+        List<Long> userExplorationIds = filterUserExplorationIds(userId, categoryId, explorationId);
 
         if (userExplorationIds.isEmpty()) {
             return PageResponse.of(List.of(), PageMeta.of(page, size, 0));
@@ -212,6 +202,19 @@ public class RecordService {
         recordMapper.deleteById(recordId);
 
         return new DeleteRecordResponse(recordId);
+    }
+
+    private List<Long> filterUserExplorationIds(Long userId, Long categoryId, Long explorationId) {
+        if (explorationId != null) {
+            return userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, List.of(explorationId));
+        } else if (categoryId != null) {
+            List<Long> explorationIds = explorationMapper.findIdsByCategoryId(categoryId);
+            return explorationIds.isEmpty()
+                    ? List.of()
+                    : userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, explorationIds);
+        } else {
+            return userExplorationMapper.findIdsByUserId(userId);
+        }
     }
 
     private void saveRecordImages(Long recordId, List<MultipartFile> files) {

--- a/src/main/java/com/jian/hobbyadventure/service/RecordService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/RecordService.java
@@ -1,0 +1,238 @@
+package com.jian.hobbyadventure.service;
+
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
+import com.jian.hobbyadventure.common.response.PageMeta;
+import com.jian.hobbyadventure.common.response.PageResponse;
+import com.jian.hobbyadventure.domain.Category;
+import com.jian.hobbyadventure.domain.Exploration;
+import com.jian.hobbyadventure.domain.ExplorationStatus;
+import com.jian.hobbyadventure.domain.Record;
+import com.jian.hobbyadventure.domain.RecordImage;
+import com.jian.hobbyadventure.domain.UserExploration;
+import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
+import com.jian.hobbyadventure.dto.response.CreateRecordResponse;
+import com.jian.hobbyadventure.dto.response.DeleteRecordResponse;
+import com.jian.hobbyadventure.dto.response.RecordDetailResponse;
+import com.jian.hobbyadventure.dto.response.RecordListItemResponse;
+import com.jian.hobbyadventure.dto.response.UpdateRecordResponse;
+import com.jian.hobbyadventure.repository.CategoryMapper;
+import com.jian.hobbyadventure.repository.ExplorationMapper;
+import com.jian.hobbyadventure.repository.RecordImageMapper;
+import com.jian.hobbyadventure.repository.RecordMapper;
+import com.jian.hobbyadventure.repository.UserExplorationMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecordService {
+
+    private final RecordMapper recordMapper;
+    private final RecordImageMapper recordImageMapper;
+    private final UserExplorationMapper userExplorationMapper;
+    private final ExplorationMapper explorationMapper;
+    private final CategoryMapper categoryMapper;
+    private final ImageService imageService;
+
+    @Value("${app.image.base-url}")
+    private String imageBaseUrl;
+
+    @Transactional
+    public CreateRecordResponse createRecord(Long userId, CreateRecordRequest request, List<MultipartFile> images) {
+        UserExploration userExploration = userExplorationMapper.findById(request.getUserExplorationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        if (!userExploration.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        if (userExploration.getStatus() != ExplorationStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.INVALID_STATE);
+        }
+
+        if (recordMapper.existsByUserExplorationId(request.getUserExplorationId())) {
+            throw new BusinessException(ErrorCode.DUPLICATED);
+        }
+
+        Record record = Record.create(
+                request.getUserExplorationId(),
+                request.getTitle(),
+                request.getVisitedDate(),
+                request.getRating(),
+                request.getEmotionCode(),
+                request.getPlaceName(),
+                request.getContent()
+        );
+
+        recordMapper.insert(record);
+
+        if (images != null && !images.isEmpty()) {
+            saveRecordImages(record.getId(), images);
+        }
+
+        return new CreateRecordResponse(record.getId());
+    }
+
+    public PageResponse<RecordListItemResponse> getRecords(Long userId, Long categoryId, Long explorationId, int page, int size) {
+        int offset = (page - 1) * size;
+
+        List<Long> userExplorationIds;
+        if (explorationId != null) {
+            userExplorationIds = userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, List.of(explorationId));
+        } else if (categoryId != null) {
+            List<Long> explorationIds = explorationMapper.findIdsByCategoryId(categoryId);
+            userExplorationIds = explorationIds.isEmpty()
+                    ? List.of()
+                    : userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, explorationIds);
+        } else {
+            userExplorationIds = userExplorationMapper.findIdsByUserId(userId);
+        }
+
+        if (userExplorationIds.isEmpty()) {
+            return PageResponse.of(List.of(), PageMeta.of(page, size, 0));
+        }
+
+        List<Record> records = recordMapper.findAllByUserExplorationIds(userExplorationIds, size, offset);
+        long totalElements = recordMapper.countByUserExplorationIds(userExplorationIds);
+
+        if (records.isEmpty()) {
+            return PageResponse.of(List.of(), PageMeta.of(page, size, totalElements));
+        }
+
+        List<Long> recordIds = records.stream().map(Record::getId).toList();
+        Map<Long, String> thumbnailMap = buildThumbnailMap(recordIds);
+
+        List<Long> ueIds = records.stream().map(Record::getUserExplorationId).distinct().toList();
+        Map<Long, UserExploration> ueMap = userExplorationMapper.findByIdIn(ueIds).stream()
+                .collect(Collectors.toMap(UserExploration::getId, ue -> ue));
+
+        List<Long> explorationIds = ueMap.values().stream().map(UserExploration::getExplorationId).distinct().toList();
+        Map<Long, Exploration> explorationMap = explorationMapper.findByIdIn(explorationIds).stream()
+                .collect(Collectors.toMap(Exploration::getId, e -> e));
+
+        Map<Long, String> categoryNameMap = categoryMapper.findAll().stream()
+                .collect(Collectors.toMap(Category::getCategoryId, Category::getName));
+
+        List<RecordListItemResponse> data = records.stream()
+                .map(record -> {
+                    UserExploration ue = ueMap.get(record.getUserExplorationId());
+                    Exploration exploration = explorationMap.get(ue.getExplorationId());
+                    String categoryName = categoryNameMap.get(exploration.getCategoryId());
+                    String thumbUrl = thumbnailMap.getOrDefault(record.getId(),
+                            exploration.getThumbnailUrl() != null ? imageBaseUrl + exploration.getThumbnailUrl() : null);
+                    return RecordListItemResponse.from(record, ue, exploration, categoryName, thumbUrl);
+                })
+                .toList();
+
+        return PageResponse.of(data, PageMeta.of(page, size, totalElements));
+    }
+
+    public RecordDetailResponse getRecord(Long userId, Long recordId) {
+        Record record = recordMapper.findById(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        UserExploration userExploration = userExplorationMapper.findById(record.getUserExplorationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        if (!userExploration.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        Exploration exploration = explorationMapper.findById(userExploration.getExplorationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        Category category = categoryMapper.findById(exploration.getCategoryId());
+
+        List<String> imageUrls = recordImageMapper.findAllByRecordId(recordId).stream()
+                .map(img -> imageBaseUrl + img.getImageUrl())
+                .toList();
+
+        return RecordDetailResponse.from(record, userExploration, exploration, category.getName(), imageUrls);
+    }
+
+    @Transactional
+    public UpdateRecordResponse updateRecord(Long userId, Long recordId, UpdateRecordRequest request, List<MultipartFile> newImages) {
+        Record record = recordMapper.findById(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        UserExploration userExploration = userExplorationMapper.findById(record.getUserExplorationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        if (!userExploration.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        if (request.getTitle() != null) record.setTitle(request.getTitle());
+        if (request.getVisitedDate() != null) record.setVisitedDate(request.getVisitedDate());
+        if (request.getRating() != null) record.setRating(request.getRating());
+        if (request.getEmotionCode() != null) record.setEmotionCode(request.getEmotionCode());
+        if (request.getContent() != null) record.setContent(request.getContent());
+        // placeName: 빈 문자열로 전달하면 null(삭제), 값이 있으면 업데이트, null이면 변경 없음
+        if (request.getPlaceName() != null) {
+            record.setPlaceName(request.getPlaceName().isBlank() ? null : request.getPlaceName());
+        }
+
+        recordMapper.update(record);
+
+        if (newImages != null) {
+            imageService.deleteImages(recordId);
+            recordImageMapper.deleteAllByRecordId(recordId);
+            if (!newImages.isEmpty()) {
+                saveRecordImages(recordId, newImages);
+            }
+        }
+
+        return new UpdateRecordResponse(recordId);
+    }
+
+    @Transactional
+    public DeleteRecordResponse deleteRecord(Long userId, Long recordId) {
+        Record record = recordMapper.findById(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        UserExploration userExploration = userExplorationMapper.findById(record.getUserExplorationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        if (!userExploration.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        imageService.deleteImages(recordId);
+        recordImageMapper.deleteAllByRecordId(recordId);
+        recordMapper.deleteById(recordId);
+
+        return new DeleteRecordResponse(recordId);
+    }
+
+    private void saveRecordImages(Long recordId, List<MultipartFile> files) {
+        List<String> relativePaths = imageService.saveImages(recordId, files);
+        List<RecordImage> recordImages = new ArrayList<>();
+        for (int i = 0; i < relativePaths.size(); i++) {
+            RecordImage ri = new RecordImage();
+            ri.setRecordId(recordId);
+            ri.setImageUrl(relativePaths.get(i));
+            ri.setImageOrder(i + 1);
+            recordImages.add(ri);
+        }
+        recordImageMapper.insertAll(recordImages);
+    }
+
+    private Map<Long, String> buildThumbnailMap(List<Long> recordIds) {
+        return recordImageMapper.findAllByRecordIds(recordIds).stream()
+                .collect(Collectors.toMap(
+                        RecordImage::getRecordId,
+                        img -> imageBaseUrl + img.getImageUrl(),
+                        (existing, replacement) -> existing
+                ));
+    }
+}

--- a/src/main/java/com/jian/hobbyadventure/service/RecordService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/RecordService.java
@@ -112,7 +112,7 @@ public class RecordService {
         List<Long> recordIds = records.stream().map(Record::getId).toList();
         Map<Long, String> thumbnailMap = buildThumbnailMap(recordIds);
 
-        List<Long> ueIds = records.stream().map(Record::getUserExplorationId).distinct().toList();
+        List<Long> ueIds = records.stream().map(Record::getUserExplorationId).toList();
         Map<Long, UserExploration> ueMap = userExplorationMapper.findByIdIn(ueIds).stream()
                 .collect(Collectors.toMap(UserExploration::getId, ue -> ue));
 

--- a/src/main/java/com/jian/hobbyadventure/service/RecordService.java
+++ b/src/main/java/com/jian/hobbyadventure/service/RecordService.java
@@ -11,6 +11,7 @@ import com.jian.hobbyadventure.domain.Record;
 import com.jian.hobbyadventure.domain.RecordImage;
 import com.jian.hobbyadventure.domain.UserExploration;
 import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.RecordSearchCondition;
 import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
 import com.jian.hobbyadventure.dto.response.CreateRecordResponse;
 import com.jian.hobbyadventure.dto.response.DeleteRecordResponse;
@@ -83,10 +84,10 @@ public class RecordService {
         return new CreateRecordResponse(record.getId());
     }
 
-    public PageResponse<RecordListItemResponse> getRecords(Long userId, Long categoryId, Long explorationId, int page, int size) {
+    public PageResponse<RecordListItemResponse> getRecords(Long userId, RecordSearchCondition condition, int page, int size) {
         int offset = (page - 1) * size;
 
-        List<Long> userExplorationIds = filterUserExplorationIds(userId, categoryId, explorationId);
+        List<Long> userExplorationIds = filterUserExplorationIds(userId, condition);
 
         if (userExplorationIds.isEmpty()) {
             return PageResponse.of(List.of(), PageMeta.of(page, size, 0));
@@ -204,11 +205,11 @@ public class RecordService {
         return new DeleteRecordResponse(recordId);
     }
 
-    private List<Long> filterUserExplorationIds(Long userId, Long categoryId, Long explorationId) {
-        if (explorationId != null) {
-            return userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, List.of(explorationId));
-        } else if (categoryId != null) {
-            List<Long> explorationIds = explorationMapper.findIdsByCategoryId(categoryId);
+    private List<Long> filterUserExplorationIds(Long userId, RecordSearchCondition condition) {
+        if (condition.hasExplorationFilter()) {
+            return userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, List.of(condition.explorationId()));
+        } else if (condition.hasCategoryFilter()) {
+            List<Long> explorationIds = explorationMapper.findIdsByCategoryId(condition.categoryId());
             return explorationIds.isEmpty()
                     ? List.of()
                     : userExplorationMapper.findIdsByUserIdAndExplorationIds(userId, explorationIds);

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -49,3 +49,30 @@ CREATE TABLE user_explorations
     CONSTRAINT fk_user_explorations_exploration FOREIGN KEY (exploration_id) REFERENCES explorations (id)
 );
 
+CREATE TABLE records
+(
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    user_exploration_id BIGINT       NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    visited_date        DATE         NOT NULL,
+    rating              TINYINT      NOT NULL,
+    emotion_code        VARCHAR(30)  NOT NULL,
+    place_name          VARCHAR(255),
+    content             TEXT         NOT NULL,
+    created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_records_user_exploration FOREIGN KEY (user_exploration_id) REFERENCES user_explorations (id)
+);
+
+CREATE TABLE record_images
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    record_id   BIGINT       NOT NULL,
+    image_url   VARCHAR(500) NOT NULL,
+    image_order INT          NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_record_images_record FOREIGN KEY (record_id) REFERENCES records (id)
+);
+

--- a/src/test/java/com/jian/hobbyadventure/controller/RecordControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/RecordControllerTest.java
@@ -58,7 +58,7 @@ class RecordControllerTest {
                 new RecordListItemResponse(1L, 1L, 10L, "수채화 그리기 입문", 5L, "학습", "test title",
                         null, LocalDate.of(2025, 6, 1), 4, "HAPPY", "행복", LocalDateTime.now())
         );
-        when(recordService.getRecords(anyLong(), any(), any(), anyInt(), anyInt()))
+        when(recordService.getRecords(anyLong(), any(), anyInt(), anyInt()))
                 .thenReturn(PageResponse.of(data, PageMeta.of(1, 10, 1)));
 
         mockMvc.perform(get("/api/v1/records").header("X-User-Id", 1L))

--- a/src/test/java/com/jian/hobbyadventure/controller/RecordControllerTest.java
+++ b/src/test/java/com/jian/hobbyadventure/controller/RecordControllerTest.java
@@ -1,0 +1,146 @@
+package com.jian.hobbyadventure.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
+import com.jian.hobbyadventure.common.response.PageMeta;
+import com.jian.hobbyadventure.common.response.PageResponse;
+import com.jian.hobbyadventure.domain.Emotion;
+import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
+import com.jian.hobbyadventure.dto.response.CreateRecordResponse;
+import com.jian.hobbyadventure.dto.response.DeleteRecordResponse;
+import com.jian.hobbyadventure.dto.response.RecordDetailResponse;
+import com.jian.hobbyadventure.dto.response.RecordListItemResponse;
+import com.jian.hobbyadventure.dto.response.UpdateRecordResponse;
+import com.jian.hobbyadventure.service.RecordService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecordController.class)
+class RecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RecordService recordService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void getRecords_성공_시_200을_반환한다() throws Exception {
+        List<RecordListItemResponse> data = List.of(
+                new RecordListItemResponse(1L, 1L, 10L, "수채화 그리기 입문", 5L, "학습", "test title",
+                        null, LocalDate.of(2025, 6, 1), 4, "HAPPY", "행복", LocalDateTime.now())
+        );
+        when(recordService.getRecords(anyLong(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(PageResponse.of(data, PageMeta.of(1, 10, 1)));
+
+        mockMvc.perform(get("/api/v1/records").header("X-User-Id", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("test title"))
+                .andExpect(jsonPath("$.meta.totalElements").value(1));
+    }
+
+    @Test
+    void createRecord_성공_시_201을_반환한다() throws Exception {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        MockMultipartFile requestPart = new MockMultipartFile("request", "", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+        when(recordService.createRecord(anyLong(), any(), any())).thenReturn(new CreateRecordResponse(1L));
+
+        mockMvc.perform(multipart("/api/v1/records").file(requestPart).header("X-User-Id", 1L))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.recordId").value(1L));
+    }
+
+    @Test
+    void createRecord_필수값_누락_시_400을_반환한다() throws Exception {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        MockMultipartFile requestPart = new MockMultipartFile("request", "", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+
+        mockMvc.perform(multipart("/api/v1/records").file(requestPart).header("X-User-Id", 1L))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getRecord_성공_시_200을_반환한다() throws Exception {
+        RecordDetailResponse response = new RecordDetailResponse(
+                1L, 1L, 10L, "수채화 그리기 입문", 5L, "학습", "test title",
+                LocalDate.of(2025, 6, 1), 4, "HAPPY", "행복", null, "content",
+                List.of(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        when(recordService.getRecord(1L, 1L)).thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/records/1").header("X-User-Id", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recordId").value(1L))
+                .andExpect(jsonPath("$.data.title").value("test title"));
+    }
+
+    @Test
+    void getRecord_존재하지_않으면_404를_반환한다() throws Exception {
+        doThrow(new BusinessException(ErrorCode.NOT_FOUND)).when(recordService).getRecord(anyLong(), anyLong());
+
+        mockMvc.perform(get("/api/v1/records/1").header("X-User-Id", 1L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("요청하신 정보를 찾을 수 없습니다."));
+    }
+
+    @Test
+    void getRecord_다른_유저_접근_시_403을_반환한다() throws Exception {
+        doThrow(new BusinessException(ErrorCode.FORBIDDEN)).when(recordService).getRecord(anyLong(), anyLong());
+
+        mockMvc.perform(get("/api/v1/records/1").header("X-User-Id", 2L))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+    }
+
+    @Test
+    void updateRecord_성공_시_200을_반환한다() throws Exception {
+        MockMultipartFile requestPart = new MockMultipartFile("request", "", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(new UpdateRecordRequest("new title", null, null, null, null, null)));
+        when(recordService.updateRecord(anyLong(), anyLong(), any(), any())).thenReturn(new UpdateRecordResponse(1L));
+
+        mockMvc.perform(multipart("/api/v1/records/1").file(requestPart)
+                        .with(req -> { req.setMethod("PATCH"); return req; })
+                        .header("X-User-Id", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recordId").value(1L));
+    }
+
+    @Test
+    void deleteRecord_성공_시_200을_반환한다() throws Exception {
+        when(recordService.deleteRecord(anyLong(), anyLong())).thenReturn(new DeleteRecordResponse(1L));
+
+        mockMvc.perform(delete("/api/v1/records/1").header("X-User-Id", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recordId").value(1L));
+    }
+}

--- a/src/test/java/com/jian/hobbyadventure/service/RecordServiceTest.java
+++ b/src/test/java/com/jian/hobbyadventure/service/RecordServiceTest.java
@@ -1,0 +1,233 @@
+package com.jian.hobbyadventure.service;
+
+import com.jian.hobbyadventure.common.exception.BusinessException;
+import com.jian.hobbyadventure.common.exception.ErrorCode;
+import com.jian.hobbyadventure.domain.Category;
+import com.jian.hobbyadventure.domain.Emotion;
+import com.jian.hobbyadventure.domain.Exploration;
+import com.jian.hobbyadventure.domain.ExplorationStatus;
+import com.jian.hobbyadventure.domain.Record;
+import com.jian.hobbyadventure.domain.UserExploration;
+import com.jian.hobbyadventure.dto.request.CreateRecordRequest;
+import com.jian.hobbyadventure.dto.request.UpdateRecordRequest;
+import com.jian.hobbyadventure.dto.response.RecordDetailResponse;
+import com.jian.hobbyadventure.dto.response.UpdateRecordResponse;
+import com.jian.hobbyadventure.repository.CategoryMapper;
+import com.jian.hobbyadventure.repository.ExplorationMapper;
+import com.jian.hobbyadventure.repository.RecordImageMapper;
+import com.jian.hobbyadventure.repository.RecordMapper;
+import com.jian.hobbyadventure.repository.UserExplorationMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecordServiceTest {
+
+    @Mock private RecordMapper recordMapper;
+    @Mock private RecordImageMapper recordImageMapper;
+    @Mock private UserExplorationMapper userExplorationMapper;
+    @Mock private ExplorationMapper explorationMapper;
+    @Mock private CategoryMapper categoryMapper;
+    @Mock private ImageService imageService;
+
+    @InjectMocks
+    private RecordService recordService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(recordService, "imageBaseUrl", "/images/");
+    }
+
+    private UserExploration createUserExploration(Long id, Long userId, Long explorationId, ExplorationStatus status) {
+        UserExploration ue = new UserExploration();
+        ue.setId(id);
+        ue.setUserId(userId);
+        ue.setExplorationId(explorationId);
+        ue.setStatus(status);
+        return ue;
+    }
+
+    private Record createRecord(Long id, Long userExplorationId) {
+        Record record = Record.create(userExplorationId, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        record.setId(id);
+        return record;
+    }
+
+    private Exploration createExploration(Long id, Long categoryId) {
+        Exploration exploration = new Exploration();
+        exploration.setId(id);
+        exploration.setCategoryId(categoryId);
+        exploration.setTitle("탐험 제목");
+        return exploration;
+    }
+
+    private Category createCategory(Long id, String name) {
+        Category category = new Category();
+        category.setCategoryId(id);
+        category.setName(name);
+        return category;
+    }
+
+    @Test
+    void createRecord_성공_시_recordMapper_insert가_호출된다() {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.COMPLETED)));
+        when(recordMapper.existsByUserExplorationId(1L)).thenReturn(false);
+
+        recordService.createRecord(1L, request, null);
+
+        verify(recordMapper).insert(any());
+    }
+
+    @Test
+    void createRecord_존재하지_않는_userExploration_시_NOT_FOUND를_던진다() {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> recordService.createRecord(1L, request, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void createRecord_다른_유저의_탐험_시_FORBIDDEN을_던진다() {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 2L, 10L, ExplorationStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> recordService.createRecord(1L, request, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void createRecord_COMPLETED가_아닌_탐험_시_INVALID_STATE를_던진다() {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.STARTED)));
+
+        assertThatThrownBy(() -> recordService.createRecord(1L, request, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_STATE);
+    }
+
+    @Test
+    void createRecord_이미_기록이_있으면_DUPLICATED를_던진다() {
+        CreateRecordRequest request = new CreateRecordRequest(1L, "title", LocalDate.of(2025, 6, 1), 4, Emotion.HAPPY, null, "content");
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.COMPLETED)));
+        when(recordMapper.existsByUserExplorationId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> recordService.createRecord(1L, request, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATED);
+    }
+
+    @Test
+    void getRecord_성공_시_기록_상세를_반환한다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(createRecord(1L, 1L)));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.COMPLETED)));
+        when(explorationMapper.findById(10L)).thenReturn(Optional.of(createExploration(10L, 5L)));
+        when(categoryMapper.findById(5L)).thenReturn(createCategory(5L, "학습"));
+        when(recordImageMapper.findAllByRecordId(1L)).thenReturn(List.of());
+
+        RecordDetailResponse result = recordService.getRecord(1L, 1L);
+
+        assertThat(result.getRecordId()).isEqualTo(1L);
+        assertThat(result.getCategoryName()).isEqualTo("학습");
+        assertThat(result.getImageUrls()).isEmpty();
+    }
+
+    @Test
+    void getRecord_존재하지_않는_기록_시_NOT_FOUND를_던진다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> recordService.getRecord(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void getRecord_다른_유저의_기록_시_FORBIDDEN을_던진다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(createRecord(1L, 1L)));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 2L, 10L, ExplorationStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> recordService.getRecord(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void updateRecord_성공_시_recordMapper_update가_호출된다() {
+        Record record = createRecord(1L, 1L);
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(record));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.COMPLETED)));
+
+        UpdateRecordResponse result = recordService.updateRecord(1L, 1L, new UpdateRecordRequest("new title", null, null, null, null, null), null);
+
+        assertThat(result.getRecordId()).isEqualTo(1L);
+        verify(recordMapper).update(record);
+    }
+
+    @Test
+    void updateRecord_존재하지_않는_기록_시_NOT_FOUND를_던진다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> recordService.updateRecord(1L, 1L, new UpdateRecordRequest(null, null, null, null, null, null), null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void updateRecord_다른_유저의_기록_시_FORBIDDEN을_던진다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(createRecord(1L, 1L)));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 2L, 10L, ExplorationStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> recordService.updateRecord(1L, 1L, new UpdateRecordRequest(null, null, null, null, null, null), null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void deleteRecord_성공_시_파일과_DB가_순서대로_삭제된다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(createRecord(1L, 1L)));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 1L, 10L, ExplorationStatus.COMPLETED)));
+
+        recordService.deleteRecord(1L, 1L);
+
+        verify(imageService).deleteImages(1L);
+        verify(recordImageMapper).deleteAllByRecordId(1L);
+        verify(recordMapper).deleteById(1L);
+    }
+
+    @Test
+    void deleteRecord_다른_유저의_기록_시_FORBIDDEN을_던진다() {
+        when(recordMapper.findById(1L)).thenReturn(Optional.of(createRecord(1L, 1L)));
+        when(userExplorationMapper.findById(1L)).thenReturn(Optional.of(createUserExploration(1L, 2L, 10L, ExplorationStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> recordService.deleteRecord(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -46,3 +46,30 @@ CREATE TABLE user_explorations
     CONSTRAINT fk_user_explorations_user FOREIGN KEY (user_id) REFERENCES users (user_id),
     CONSTRAINT fk_user_explorations_exploration FOREIGN KEY (exploration_id) REFERENCES explorations (id)
 );
+
+CREATE TABLE records
+(
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    user_exploration_id BIGINT       NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    visited_date        DATE         NOT NULL,
+    rating              TINYINT      NOT NULL,
+    emotion_code        VARCHAR(30)  NOT NULL,
+    place_name          VARCHAR(255),
+    content             TEXT         NOT NULL,
+    created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_records_user_exploration FOREIGN KEY (user_exploration_id) REFERENCES user_explorations (id)
+);
+
+CREATE TABLE record_images
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    record_id   BIGINT       NOT NULL,
+    image_url   VARCHAR(500) NOT NULL,
+    image_order INT          NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_record_images_record FOREIGN KEY (record_id) REFERENCES records (id)
+);


### PR DESCRIPTION
## 개요

사용자가 완료한 탐험에 대해 기록을 작성하고,
자신의 기록을 조회, 수정, 삭제할 수 있는 기록 API를 구현했습니다.

## Issue

#27

## 주요 구현 내용

* 기록 CRUD API 구현
* `records`, `record_images` 테이블 설계
* 기록 감정 값 Enum 정의
* 이미지 업로드 및 저장 처리 구현
* 기록 생성/수정 요청 검증 구현
* 기록 소유자 기반 접근 권한 검증 구현
* 테스트 코드 작성
* Swagger API 문서 작성

## 리뷰 시 참고 사항

* 기록 생성/수정 API는 이미지 업로드가 필요해 `multipart/form-data`로 처리했습니다.
  본문 데이터는 `@RequestPart("request")`로 DTO에 매핑하고, 이미지 파일은 `@RequestPart("images")`로 분리했습니다.

* 업로드 이미지는 원본 파일명을 그대로 사용하지 않고 UUID 기반 파일명으로 저장했습니다.
  파일명 충돌을 줄이기 위해 원본 파일명과 실제 저장 파일명을 DB에 함께 저장했습니다.

* 기록 삭제 시 DB 데이터뿐 아니라 디스크에 저장된 이미지 파일도 함께 삭제하도록 처리했습니다.
  다만 파일 삭제는 DB 트랜잭션에 포함되지 않으므로, 현재는 프로젝트 규모를 고려해 단순 삭제 방식으로 구현했습니다.

* 기록 수정은 XML 동적 UPDATE 대신, 기존 기록을 조회한 뒤 서비스 계층에서 요청 값을 병합하고 전체 UPDATE하는 방식으로 처리했습니다.

* 생성, 수정, 삭제 응답은 현재 모두 `recordId`만 반환하지만, API별 의미와 추후 확장 가능성을 고려해 DTO를 분리했습니다.

## 리뷰 요청

* `multipart/form-data` 요청에서 본문 DTO와 이미지 파일을 `RequestPart`로 분리한 방식이 적절한지 확인 부탁드립니다.
* 기록 삭제 시 이미지 파일 삭제와 DB 삭제를 서비스 계층에서 함께 처리한 방식이 적절한지 확인 부탁드립니다.
* `PATCH` 수정 처리에서 서비스 계층 병합 후 전체 UPDATE를 수행한 방식이 적절한지 확인 부탁드립니다.

## 테스트

* 기록 CRUD 정상 동작 확인
* 완료되지 않은 탐험에 기록 작성 시 예외 처리 확인
* 본인 기록이 아닌 경우 접근 제한 확인
* 유효하지 않은 생성/수정 요청 예외 처리 확인
* 이미지 업로드 및 삭제 처리 확인
* Swagger API 확인 완료

## 체크리스트

* [x] 관련 issue를 연결했습니다.
* [x] 셀프 리뷰를 진행했습니다.
* [x] 테스트를 통해 정상 동작을 확인했습니다.
* [x] Swagger에서 API를 확인했습니다.
